### PR TITLE
reduce regex to match hex only. fixes #9

### DIFF
--- a/src/claim.coffee
+++ b/src/claim.coffee
@@ -55,7 +55,7 @@ request.variables = ->
 validate = (vars) ->
   return 'TrustedForm cert URL must not be blank' unless vars.lead.trustedform_cert_url
   # https://cert.trustedform.com/2605ec3a321e1b3a41addf0bba1213505ef57985
-  tfRegex = /https:\/\/cert.trustedform.com\/[a-z0-9]{40}/
+  tfRegex = /https:\/\/cert.trustedform.com\/[a-h0-9]{40}/
   return 'TrustedForm cert URL must be valid' unless tfRegex.test(vars.lead.trustedform_cert_url)
 
 


### PR DESCRIPTION
As in #9, except kept the `[brackets]` and didn't add the ignore case flag `i`.