### PR TITLE
Refine age in seconds to account for time spent on page

### DIFF
--- a/spec/claim_spec.coffee
+++ b/spec/claim_spec.coffee
@@ -283,6 +283,12 @@ describe 'Claim Response', ->
         assert.equal response.outcome, "success"
         assert.equal response.reason, null
 
+      it 'age in seconds includes event duration when present', ->
+        vars = {}
+        body = event_duration: 61999
+        response = getResponse(body, vars)
+        assert.equal response.age_in_seconds, 172353 # 172291s + 61.999s
+
   it 'returns an error when cert not found', ->
     res  =
       status: 404
@@ -366,6 +372,8 @@ responseBody = (vars = {}) ->
     vendor: null
     warnings: vars.warnings || []
 
+  response.event_duration = vars.event_duration if vars.event_duration?
+
   JSON.stringify(response)
 
 
@@ -389,7 +397,7 @@ expected = (vars = {}) ->
   masked: false
   url: vars.url || null
   domain: vars.domain || "localhost"
-  age_in_seconds: 172290
+  age_in_seconds: 172291
   created_at: "2014-04-02T21:24:22Z"
   scans:
     found: []

--- a/src/claim.coffee
+++ b/src/claim.coffee
@@ -63,9 +63,10 @@ validate = (vars) ->
 # Response Function ------------------------------------------------------
 #
 
-ageInSeconds = (date) ->
-  difference = Date.now() - new Date(date)
-  Math.floor difference / 1000
+ageInSeconds = (claim) ->
+  difference = Date.now() - new Date(claim.cert.created_at)
+  difference += parseInt(claim.event_duration) if claim.event_duration? and not isNaN(claim.event_duration)
+  Math.round difference / 1000
 
 
 formatScanReason = (scannedFor, textArray) ->
@@ -101,7 +102,7 @@ response = (vars, req, res) ->
       masked: event.masked
       url: hosted_url
       domain: url.parse(hosted_url).hostname if hosted_url?
-      age_in_seconds: ageInSeconds event.cert.created_at
+      age_in_seconds: ageInSeconds event
       created_at: event.cert.created_at
       scans:
         found: event.scans?.found || []


### PR DESCRIPTION
When a cert is captured with 'video', the age in seconds does not include the time the consumer spent filling out the form. 

https://github.com/activeprospect/trustedform/commit/40710d0#diff-87119a2a8497d0eeb372ebc03edb1628R21