### PR TITLE
Tf improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org)
 
+## [1.9.0] - 2018-04-09
+### Added
+- Parse 404 errors returned by bad cert hashes
+- Add `how_many_required_matched` appended data
+
 ## [1.8.0] - 2018-04-05
 ### Added
 - Add error message for expiration errors (410)

--- a/lib/claim.js
+++ b/lib/claim.js
@@ -1,6 +1,6 @@
 const url = require('url');
 const _ = require('lodash');
-const { content, ageInSeconds, timeOnPageInSeconds, formatScanReason, countScannedRequiredStrings } = require('./helpers.js');
+const { content, ageInSeconds, timeOnPageInSeconds, formatScanReason, countRequiredMatched } = require('./helpers.js');
 
 const request = (vars) => {
 
@@ -52,10 +52,7 @@ const response  = (vars, req, res) => {
   try {
     event = JSON.parse(res.body);
   } catch(e) {
-    /*
-      This bit can probably be refactored out after the TF cert changes land.
-      See this PR for more info: https://github.com/activeprospect/leadconduit-integration-trustedform/pull/52
-    */
+    // This bit can probably be refactored out after the TF cert changes land. - Blake, 4/9/18
     event.message = (res.status === 404) ? res.body : 'unable to parse response';
   }
 
@@ -98,7 +95,7 @@ const response  = (vars, req, res) => {
     };
 
     const requiredStrings = _.get(vars, 'trustedform.scan_required_text', null);
-    if (requiredStrings) appended.scans.how_many_required_found = countScannedRequiredStrings(requiredStrings, appended.scans.found); // 'all', 'some', or 'none'
+    if (requiredStrings) appended.scans.how_many_required_matched = countRequiredMatched(requiredStrings, appended.scans.found); // 'all', 'some', or 'none'
 
     if (event.warnings) {
       if (event.warnings.some((warning) => warning === 'string not found in snapshot')) {

--- a/lib/claim.js
+++ b/lib/claim.js
@@ -53,12 +53,8 @@ const response  = (vars, req, res) => {
     event = JSON.parse(res.body);
   } catch(e) {
     /*
-      The TF API sends back a string (non-JSON) response if given an
-      invalid (or non-existent) hash. Historically, requests with invalid hashes
-      have been caught by `validate()` before being sent. However, cert url validation
-      has been changed in anticipation of TF API changes. Once said changes
-      have been made, this bit can probably be refactored out and handled during validation.
-      ie: invalidate the request if the url doesn't contain a valid hash
+      This bit can probably be refactored out after the TF cert changes land.
+      See this PR for more info: https://github.com/activeprospect/leadconduit-integration-trustedform/pull/52
     */
     event.message = (res.status === 404) ? res.body : 'unable to parse response';
   }

--- a/lib/claim.js
+++ b/lib/claim.js
@@ -108,8 +108,15 @@ const response  = (vars, req, res) => {
   try {
     event = JSON.parse(res.body);
   } catch(e) {
-    event.message = 'unable to parse response' ;
+    // Once the new TF cert url is established, this can be refactored out and handled during validation.
+    // ie: invalidate the request if the url doesn't contain a valid hash
+    if (res.status === 404) {
+      event.message = res.body;
+    } else {
+      event.message = 'unable to parse response';
+    }
   }
+
 
   if (res.status === 201 && event.cert) {
     let hosted_url = event.cert.parent_location || event.cert.location;

--- a/lib/claim.js
+++ b/lib/claim.js
@@ -95,7 +95,7 @@ const response  = (vars, req, res) => {
     };
 
     const requiredStrings = _.get(vars, 'trustedform.scan_required_text', null);
-    if (requiredStrings) appended.scans.how_many_required_matched = countRequiredMatched(requiredStrings, appended.scans.found); // 'all', 'some', or 'none'
+    if (requiredStrings) appended.scans.num_required_matched = countRequiredMatched(requiredStrings, appended.scans.found); // 'all', 'some', or 'none'
 
     if (event.warnings) {
       if (event.warnings.some((warning) => warning === 'string not found in snapshot')) {
@@ -152,7 +152,7 @@ response.variables = () => [
   { name: 'share_url', type: 'url', description: 'The expiring share URL of the certificate' },
   { name: 'scans.found', type: 'array', description: 'Forbidden scan terms found in the claim'},
   { name: 'scans.not_found', type: 'array', description: 'Required scan terms not found in the claim'},
-  { name: 'scans.how_many_required_matched', type: 'string', description: 'How many of the required strings were scanned? (all, some, none)'},
+  { name: 'scans.num_required_matched', type: 'string', description: 'How many of the required strings were scanned? (all, some, none)'},
   { name: 'duration', type: 'number', description: 'The number of seconds the API call took, according to TrustedForm'}
 ];
 

--- a/lib/claim.js
+++ b/lib/claim.js
@@ -152,6 +152,7 @@ response.variables = () => [
   { name: 'share_url', type: 'url', description: 'The expiring share URL of the certificate' },
   { name: 'scans.found', type: 'array', description: 'Forbidden scan terms found in the claim'},
   { name: 'scans.not_found', type: 'array', description: 'Required scan terms not found in the claim'},
+  { name: 'scans.how_many_required_matched', type: 'string', description: 'How many of the required strings were scanned? (all, some, none)'},
   { name: 'duration', type: 'number', description: 'The number of seconds the API call took, according to TrustedForm'}
 ];
 

--- a/lib/claim.js
+++ b/lib/claim.js
@@ -1,43 +1,6 @@
-const querystring = require('querystring');
 const url = require('url');
 const _ = require('lodash');
-
-const content = (vars) => {
-
-  const vendor = (vars.trustedform && vars.trustedform.vendor) ?
-    vars.trustedform.vendor :
-    vars.source.name;
-
-  const params = {
-    reference: `https://next.leadconduit.com/events/${vars.lead.id}`,
-    vendor
-  };
-
-  if (vars.trustedform && vars.trustedform.scan_required_text) {
-    // Convert scan_required_text to Array if it isn't already
-    if (!(vars.trustedform.scan_required_text instanceof Array)) {
-      vars.trustedform.scan_required_text = [ vars.trustedform.scan_required_text ];
-    }
-    params['scan[]'] = vars.trustedform.scan_required_text;
-  }
-
-
-  if (vars.trustedform && vars.trustedform.scan_forbidden_text) {
-    if (!(vars.trustedform.scan_forbidden_text instanceof Array)) {
-      vars.trustedform.scan_forbidden_text = [ vars.trustedform.scan_forbidden_text ];
-    }
-    params['scan![]'] = vars.trustedform.scan_forbidden_text;
-  }
-
-  if (vars.lead.email) params.email = vars.lead.email.toString();
-  if (vars.lead.phone_1) params.phone_1 = vars.lead.phone_1.toString();
-  if (vars.lead.phone_2) params.phone_2 = vars.lead.phone_2.toString();
-  if (vars.lead.phone_3) params.phone_3 = vars.lead.phone_3.toString();
-
-  return querystring.encode(params);
-};
-
-const encodeAuthentication = (apiKey) => `Basic ${new Buffer(`API:${apiKey}`).toString('base64')}`;
+const { content, ageInSeconds, timeOnPageInSeconds, formatScanReason, countScannedRequiredStrings } = require('./helpers.js');
 
 const request = (vars) => {
 
@@ -55,7 +18,7 @@ const request = (vars) => {
     method: 'POST',
     headers: {
       Accept:        'application/json',
-      Authorization:  encodeAuthentication(apiKey),
+      Authorization:  `Basic ${new Buffer(`API:${apiKey}`).toString('base64')}`,
       'Content-Type': 'application/x-www-form-urlencoded'
     },
     body: content(vars)
@@ -74,31 +37,12 @@ request.variables = () => [
   { name: 'lead.phone_3', type: 'string', required: false, description: `Lead phone 3 that will be fingerprinted, defaults to the lead's "Phone 3" field` }
 ];
 
-
 const validate = (vars) => {
   if (!vars.lead.trustedform_cert_url) return 'TrustedForm cert URL must not be blank';
 
   // Cert URLs should begin with 'https://cert.trustedform.com/'
   const tfRegex = /^https:\/\/cert.trustedform.com\//;
   if (!tfRegex.test(vars.lead.trustedform_cert_url)) return 'TrustedForm cert URL must be valid';
-};
-
-
-const ageInSeconds = (event) => {
-  const timeOnPage = timeOnPageInSeconds(event.cert.event_duration) || 0;
-  const certAge = (new Date(event.created_at) - new Date(event.cert.created_at)) / 1000;
-  return Math.round(certAge - timeOnPage);
-};
-
-const timeOnPageInSeconds = (event_duration) => {
-  if (!event_duration || isNaN(event_duration)) return null;
-  return Math.round(parseInt(event_duration) / 1000);
-};
-
-const formatScanReason = (scannedFor, textArray)=> {
-  const matches = textArray.filter(t => scannedFor.indexOf(t) >= 0);
-  // sort text items for uniformity of reason across leads, and (arbitrarily) limit in case of long scan text
-  return `${matches.length}: '${matches.sort().join(', ').substr(0, 255)}'`;
 };
 
 const response  = (vars, req, res) => {
@@ -108,15 +52,16 @@ const response  = (vars, req, res) => {
   try {
     event = JSON.parse(res.body);
   } catch(e) {
-    // Once the new TF cert url is established, this can be refactored out and handled during validation.
-    // ie: invalidate the request if the url doesn't contain a valid hash
-    if (res.status === 404) {
-      event.message = res.body;
-    } else {
-      event.message = 'unable to parse response';
-    }
+    /*
+      The TF API sends back a string (non-JSON) response if given an
+      invalid (or non-existent) hash. Historically, requests with invalid hashes
+      have been caught by `validate()` before being sent. However, cert url validation
+      has been changed in anticipation of TF API changes. Once said changes
+      have been made, this bit can probably be refactored out and handled during validation.
+      ie: invalidate the request if the url doesn't contain a valid hash
+    */
+    event.message = (res.status === 404) ? res.body : 'unable to parse response';
   }
-
 
   if (res.status === 201 && event.cert) {
     let hosted_url = event.cert.parent_location || event.cert.location;
@@ -155,6 +100,9 @@ const response  = (vars, req, res) => {
       },
       duration: res.headers['X-Runtime']
     };
+
+    const requiredStrings = _.get(vars, 'trustedform.scan_required_text', null);
+    if (requiredStrings) appended.scans.how_many_required_found = countScannedRequiredStrings(requiredStrings, appended.scans.found); // 'all', 'some', or 'none'
 
     if (event.warnings) {
       if (event.warnings.some((warning) => warning === 'string not found in snapshot')) {
@@ -213,7 +161,6 @@ response.variables = () => [
   { name: 'scans.not_found', type: 'array', description: 'Required scan terms not found in the claim'},
   { name: 'duration', type: 'number', description: 'The number of seconds the API call took, according to TrustedForm'}
 ];
-
 
 module.exports = {
   validate,

--- a/lib/claim.js
+++ b/lib/claim.js
@@ -52,7 +52,6 @@ const response  = (vars, req, res) => {
   try {
     event = JSON.parse(res.body);
   } catch(e) {
-    // This bit can probably be refactored out after the TF cert changes land. - Blake, 4/9/18
     event.message = (res.status === 404) ? res.body : 'unable to parse response';
   }
 

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -1,0 +1,79 @@
+const querystring = require('querystring');
+
+const content = (vars) => {
+
+  const vendor = (vars.trustedform && vars.trustedform.vendor) ?
+    vars.trustedform.vendor :
+    vars.source.name;
+
+  const params = {
+    reference: `https://next.leadconduit.com/events/${vars.lead.id}`,
+    vendor
+  };
+
+  if (vars.trustedform && vars.trustedform.scan_required_text) {
+    // Convert scan_required_text to Array if it isn't already
+    if (!(vars.trustedform.scan_required_text instanceof Array)) {
+      vars.trustedform.scan_required_text = [ vars.trustedform.scan_required_text ];
+    }
+    params['scan[]'] = vars.trustedform.scan_required_text;
+  }
+
+  if (vars.trustedform && vars.trustedform.scan_forbidden_text) {
+    if (!(vars.trustedform.scan_forbidden_text instanceof Array)) {
+      vars.trustedform.scan_forbidden_text = [ vars.trustedform.scan_forbidden_text ];
+    }
+    params['scan![]'] = vars.trustedform.scan_forbidden_text;
+  }
+
+  if (vars.lead.email) params.email = vars.lead.email.toString();
+  if (vars.lead.phone_1) params.phone_1 = vars.lead.phone_1.toString();
+  if (vars.lead.phone_2) params.phone_2 = vars.lead.phone_2.toString();
+  if (vars.lead.phone_3) params.phone_3 = vars.lead.phone_3.toString();
+
+  return querystring.encode(params);
+};
+
+const ageInSeconds = (event) => {
+  const timeOnPage = timeOnPageInSeconds(event.cert.event_duration) || 0;
+  const certAge = (new Date(event.created_at) - new Date(event.cert.created_at)) / 1000;
+  return Math.round(certAge - timeOnPage);
+};
+
+const timeOnPageInSeconds = (event_duration) => {
+  if (!event_duration || isNaN(event_duration)) return null;
+  return Math.round(parseInt(event_duration) / 1000);
+};
+
+const formatScanReason = (scannedFor, textArray)=> {
+  const matches = textArray.filter(t => scannedFor.indexOf(t) >= 0);
+  // sort text items for uniformity of reason across leads, and (arbitrarily) limit in case of long scan text
+  return `${matches.length}: '${matches.sort().join(', ').substr(0, 255)}'`;
+};
+
+const countScannedRequiredStrings = (requiredStrings, scans) => {
+  // normalize data
+  if (!(requiredStrings instanceof Array)) {
+    requiredStrings = [requiredStrings];
+  }
+
+  if (scans.length === 0) return 'none';
+
+  let requiredStringNotFound = false;
+  requiredStrings.forEach(string => {
+    if (scans.indexOf(string) === -1) {
+      requiredStringNotFound = true;
+    }
+  });
+
+  return (requiredStringNotFound) ? 'some' : 'all';
+};
+
+
+module.exports = {
+  content,
+  ageInSeconds,
+  timeOnPageInSeconds,
+  formatScanReason,
+  countScannedRequiredStrings
+};

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -51,7 +51,7 @@ const formatScanReason = (scannedFor, textArray)=> {
   return `${matches.length}: '${matches.sort().join(', ').substr(0, 255)}'`;
 };
 
-const countScannedRequiredStrings = (requiredStrings, scans) => {
+const countRequiredMatched = (requiredStrings, scans) => {
   // normalize data
   if (!(requiredStrings instanceof Array)) {
     requiredStrings = [requiredStrings];
@@ -75,5 +75,5 @@ module.exports = {
   ageInSeconds,
   timeOnPageInSeconds,
   formatScanReason,
-  countScannedRequiredStrings
+  countRequiredMatched
 };

--- a/test/claim_spec.js
+++ b/test/claim_spec.js
@@ -490,6 +490,23 @@ describe('Claim Response', () => {
       const response = integration.response({}, {}, res);
       assert.deepEqual(expected, response);
     });
+
+    it('returns an error message when cert hash is invalid', () => {
+      const res = {
+        status: 404,
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        body: 'This Certificate of Authenticity was not found'
+      };
+      const expected = {
+        outcome: 'error',
+        reason: `TrustedForm error - This Certificate of Authenticity was not found (404)`
+      };
+
+      const response = integration.response({}, {}, res);
+      assert.deepEqual(expected, response);
+    });
   });
 });
 

--- a/test/claim_spec.js
+++ b/test/claim_spec.js
@@ -289,7 +289,7 @@ describe('Claim Response', () => {
         let response = getResponse({scans: { found: [scanText1], not_found: [] } }, vars);
         assert.equal(response.scans.found.length, 1);
         assert.equal(response.scans.found[0], scanText1);
-        assert.equal(response.scans.how_many_required_matched, 'all');
+        assert.equal(response.scans.num_required_matched, 'all');
 
         const scanText2 = 'other disclosure text';
         vars.trustedform.scan_required_text = [scanText1, scanText2];
@@ -297,7 +297,7 @@ describe('Claim Response', () => {
         assert.equal(response.scans.found.length, 2);
         assert.equal(response.scans.found[0], scanText1);
         assert.equal(response.scans.found[1], scanText2);
-        assert.equal(response.scans.how_many_required_matched, 'all');
+        assert.equal(response.scans.num_required_matched, 'all');
       });
 
       it('captures scans_not_found', () => {
@@ -311,7 +311,7 @@ describe('Claim Response', () => {
         const response = getResponse(body, vars);
         assert.equal(response.outcome, 'failure');
         assert.equal(response.reason, `Required scan text not found in TrustedForm snapshot (missing 1: 'some disclosure text')`);
-        assert.equal(response.scans.how_many_required_matched, 'none');
+        assert.equal(response.scans.num_required_matched, 'none');
       });
 
       it('correctly formats resposnse when multiple required scans are missing', () => {
@@ -320,7 +320,7 @@ describe('Claim Response', () => {
         const response = getResponse(body, vars);
         assert.equal(response.outcome, 'failure');
         assert.equal(response.reason, `Required scan text not found in TrustedForm snapshot (missing 2: 'other disclosure text, some disclosure text')`);
-        assert.equal(response.scans.how_many_required_matched, 'none');
+        assert.equal(response.scans.num_required_matched, 'none');
       });
 
       it('correctly formats reason when some required scans are missing', () => {
@@ -329,7 +329,7 @@ describe('Claim Response', () => {
         const response = getResponse(body, vars);
         assert.equal(response.outcome, 'failure');
         assert.equal(response.reason, `Required scan text not found in TrustedForm snapshot (missing 2: 'other disclosure text, some disclosure text')`);
-        assert.equal(response.scans.how_many_required_matched, 'some');
+        assert.equal(response.scans.num_required_matched, 'some');
       });
 
       it('sets failure outcome and reason when forbidden scan is present', () => {
@@ -505,7 +505,7 @@ describe('Claim Response', () => {
       assert.deepEqual(expected, response);
     });
 
-    it('returns an error message when cert hash is invalid', () => {
+    it('returns an error message when cert id is invalid', () => {
       const res = {
         status: 404,
         headers: {

--- a/test/claim_spec.js
+++ b/test/claim_spec.js
@@ -289,7 +289,7 @@ describe('Claim Response', () => {
         let response = getResponse({scans: { found: [scanText1], not_found: [] } }, vars);
         assert.equal(response.scans.found.length, 1);
         assert.equal(response.scans.found[0], scanText1);
-        assert.equal(response.scans.how_many_required_found, 'all');
+        assert.equal(response.scans.how_many_required_matched, 'all');
 
         const scanText2 = 'other disclosure text';
         vars.trustedform.scan_required_text = [scanText1, scanText2];
@@ -297,7 +297,7 @@ describe('Claim Response', () => {
         assert.equal(response.scans.found.length, 2);
         assert.equal(response.scans.found[0], scanText1);
         assert.equal(response.scans.found[1], scanText2);
-        assert.equal(response.scans.how_many_required_found, 'all');
+        assert.equal(response.scans.how_many_required_matched, 'all');
       });
 
       it('captures scans_not_found', () => {
@@ -311,7 +311,7 @@ describe('Claim Response', () => {
         const response = getResponse(body, vars);
         assert.equal(response.outcome, 'failure');
         assert.equal(response.reason, `Required scan text not found in TrustedForm snapshot (missing 1: 'some disclosure text')`);
-        assert.equal(response.scans.how_many_required_found, 'none');
+        assert.equal(response.scans.how_many_required_matched, 'none');
       });
 
       it('correctly formats resposnse when multiple required scans are missing', () => {
@@ -320,7 +320,7 @@ describe('Claim Response', () => {
         const response = getResponse(body, vars);
         assert.equal(response.outcome, 'failure');
         assert.equal(response.reason, `Required scan text not found in TrustedForm snapshot (missing 2: 'other disclosure text, some disclosure text')`);
-        assert.equal(response.scans.how_many_required_found, 'none');
+        assert.equal(response.scans.how_many_required_matched, 'none');
       });
 
       it('correctly formats reason when some required scans are missing', () => {
@@ -329,7 +329,7 @@ describe('Claim Response', () => {
         const response = getResponse(body, vars);
         assert.equal(response.outcome, 'failure');
         assert.equal(response.reason, `Required scan text not found in TrustedForm snapshot (missing 2: 'other disclosure text, some disclosure text')`);
-        assert.equal(response.scans.how_many_required_found, 'some');
+        assert.equal(response.scans.how_many_required_matched, 'some');
       });
 
       it('sets failure outcome and reason when forbidden scan is present', () => {


### PR DESCRIPTION
## Ch-Ch-Changes

1) Adds response parsing for 404s returned by cert hashes. This change can probably be refactored out after the cert url changes land.

2) Adds `how_many_required_matched` property to appended data. The proposed name was `how_many_matched`, I added the `required` bit to clarify that the data contained is relevant _only_ to required texts. I'm not sure if that name is much better though, and it certainly doesn't roll of the tongue.

3) Moves helper functions into separate file. IMHO, this makes the code easier to read, especially after adding the `countRequiredScans` function. Happy to put them back if need be.


More info can be found in the second and third items [here.](https://activeprospect.tpondemand.com/entity/2570-trustedform-improvements)