### PR TITLE
Guard against null geo data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org)
 
+## [1.9.2] - 2018-06-26
+### Fixed
+- Handle null geo data
+
 ## [1.9.1] - 2018-06-13
 ### Fixed
 - Now fails when required text is included and snapshot is missing

--- a/lib/claim.js
+++ b/lib/claim.js
@@ -69,13 +69,13 @@ const response  = (vars, req, res) => {
       os: event.cert.operating_system,
       ip: event.cert.ip,
       location : {
-        city: event.cert.geo.city,
-        country_code: event.cert.geo.country_code,
-        latitude: event.cert.geo.lat,
-        longitude: event.cert.geo.lon,
-        postal_code: event.cert.geo.postal_code,
-        state: event.cert.geo.state,
-        time_zone: event.cert.geo.time_zone
+        city: _.get(event, 'cert.geo.city', undefined),
+        country_code: _.get(event, 'cert.geo.country_code', undefined),
+        latitude: _.get(event, 'cert.geo.lat', undefined),
+        longitude: _.get(event, 'cert.geo.lon', undefined),
+        postal_code: _.get(event, 'cert.geo.postal_code', undefined),
+        state: _.get(event, 'cert.geo.state', undefined),
+        time_zone: _.get(event, 'cert.geo.time_zone', undefined)
       },
       snapshot_url: event.cert.snapshot_url,
       masked_cert_url: event.masked_cert_url,

--- a/test/claim_spec.js
+++ b/test/claim_spec.js
@@ -245,7 +245,7 @@ describe('Claim Response', () => {
         'Content-Type': 'application/json',
         'X-Runtime': 0.497349
       },
-      body: responseBody(body)
+      body: JSON.stringify(responseBody(body))
     };
     return integration.response(vars, {}, res);
   };
@@ -274,6 +274,28 @@ describe('Claim Response', () => {
     it('uses the cert location when parent location is an empty string', () => {
       const url = 'http://localhost:81/leadconduit_iframe.html';
       assert.deepEqual(getResponse({parentLocation: '', location: url}), expected({url: url}));
+    });
+
+    it('should not bonk with null geo data', () => {
+      const url = 'http://localhost:81/leadconduit_iframe.html';
+      const body = responseBody({location: url});
+      delete body.cert.geo;
+
+      const res = {
+        status: 201,
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Runtime': 0.497349
+        },
+        body: JSON.stringify(body)
+      };
+
+      const expectedResponse = expected({url  : url});
+      Object.keys(expectedResponse.location).forEach(key => {
+        expectedResponse.location[key] = undefined;
+      });
+
+      assert.deepEqual(integration.response({},{},res), expectedResponse);
     });
 
     describe('scan results parsing', () => {
@@ -619,7 +641,7 @@ const responseBody = (vars = {}) => {
   if (vars.event_duration) { response.cert.event_duration = vars.event_duration; }
   if (vars.claims) { response.cert.claims = response.cert.claims.concat(vars.claims); }
 
-  return JSON.stringify(response);
+  return response;
 };
 
 

--- a/test/claim_spec.js
+++ b/test/claim_spec.js
@@ -442,7 +442,7 @@ describe('Claim Response', () => {
 
         const response = getResponse(body, vars);
         assert.equal(response.outcome, 'failure');
-        assert.equal(response.reason, 'snapshot scan failed')
+        assert.equal(response.reason, 'snapshot scan failed');
       });
 
       it('calculates age in seconds with event_duration', () => {


### PR DESCRIPTION
FB certs do not have geo data, which is causing the integration to bonk.

[TP Ticket](https://activeprospect.tpondemand.com/entity/3586-tf-integration-needs-work-it-is)