### PR TITLE
Capture all url location data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org)
 
+## [1.11.0] - 2019-10-02
+### Added
+- Capture all URL colation data [CH #1862](https://app.clubhouse.io/active-prospect/story/1862/trustedform-integration-provide-all-url-location-data)
+
 ## [1.10.0] - 2019-05-09
 ### Added
 - Added support for fingerprint results, per [TP #8409](https://activeprospect.tpondemand.com/entity/8409-trustedform-append-fingerprinting)

--- a/lib/claim.js
+++ b/lib/claim.js
@@ -83,6 +83,10 @@ const response  = (vars, req, res) => {
       share_url: event.share_url,
       url: hosted_url,
       domain: (hosted_url) ? url.parse(hosted_url).hostname : null,
+      website: {
+        location: _.get(event, 'cert.location'),
+        parent_location: _.get(event, 'cert.parent_location')
+      },
       age_in_seconds: ageInSeconds(event),
       time_on_page_in_seconds: timeOnPageInSeconds(event.cert.event_duration),
       created_at: event.cert.created_at,
@@ -150,6 +154,8 @@ response.variables = () => [
   { name: 'snapshot_url', type: 'string', description: 'URL of the snapshot of the offer page as seen by the user' },
   { name: 'masked_cert_url', type: 'string', description: 'The certificate url that masks the lead source url and snapshot' },
   { name: 'url', type: 'string', description: 'Parent frames URL if the page is framed, or location of the page hosting the javascript' },
+  { name: 'website.location', type: 'string', description: 'The URL of the page hosting the TrustedForm script ' },
+  { name: 'website.parent_location', type: 'string', description: 'The parent frame URL when the page is framed ' },
   { name: 'domain', type: 'string', description: 'Domain of the url' },
   { name: 'age_in_seconds', type: 'number', description: 'Number of seconds since the certificate was created' },
   { name: 'time_on_page_in_seconds', type: 'number', description: 'Number of seconds the consumer spent filling out the offer form' },

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "crypto": "^1.0.1",
     "leadconduit-integration": "^0.4.1",
-    "lodash": "^4.17.4"
+    "lodash": "^4.17.15"
   },
   "devDependencies": {
     "chai": "^1.10.0",

--- a/test/claim_spec.js
+++ b/test/claim_spec.js
@@ -262,18 +262,18 @@ describe('Claim Response', () => {
 
     it('uses the location when there is no parent location', () => {
       const url = 'http://localhost:81/leadconduit_iframe.html';
-      assert.deepEqual(getResponse({location: url}), expected({url: url}));
+      assert.deepEqual(getResponse({location: url}), expected({url: url, location: url}));
     });
 
     it('uses the parent location when it is present', () => {
       const host = 'yourhost';
       const url = `http://${host}:81/my_iframe.html`;
-      assert.deepEqual(getResponse({parentLocation: url}), expected({url: url, domain: host}));
+      assert.deepEqual(getResponse({parentLocation: url}), expected({url: url, domain: host, parent_location: url}));
     });
 
     it('uses the cert location when parent location is an empty string', () => {
       const url = 'http://localhost:81/leadconduit_iframe.html';
-      assert.deepEqual(getResponse({parentLocation: '', location: url}), expected({url: url}));
+      assert.deepEqual(getResponse({parentLocation: '', location: url}), expected({url: url, location: url}));
     });
 
     it('should not bonk with null geo data', () => {
@@ -290,7 +290,7 @@ describe('Claim Response', () => {
         body: JSON.stringify(body)
       };
 
-      const expectedResponse = expected({url  : url});
+      const expectedResponse = expected({url: url, location: url});
       Object.keys(expectedResponse.location).forEach(key => {
         expectedResponse.location[key] = undefined;
       });
@@ -668,6 +668,10 @@ const expected = (vars = {}) => {
     share_url: 'https://cert.trustedform.com/935818f23f1227002279aee8ce2db094c9bfae90?shared_token=REALLONGSHAREDTOKENGOESHERE',
     url: vars.url || null,
     domain: vars.domain || 'localhost',
+    website:{
+      parent_location: vars.parent_location || null,
+      location: vars.location || null
+    },
     age_in_seconds: 33,
     time_on_page_in_seconds: null,
     created_at: '2014-04-02T21:24:22Z',


### PR DESCRIPTION
This PR explicitly captures the `location` and `parent_location` data that is piped into the `url` property. `lodash` is also update to resolve security vulnerabilities.

CH ticket for [context](https://app.clubhouse.io/active-prospect/story/1862/trustedform-integration-provide-all-url-location-data)