### PR TITLE
Replace Travis with GH Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,28 @@
+name: Testing
+
+on: push
+
+jobs:
+  test:
+
+    runs-on: ubuntu-16.04
+
+    strategy:
+      matrix:
+        node-version: [8.15, 10.x, 12.x, 14.x]
+      
+    env:
+      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+  
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+    - run: npm install
+    - name: Run tests
+      run: npm run test:coverage:lcov
+    - uses: codecov/codecov-action@v1
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }} 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,0 @@
-language: node_js
-node_js:
-  - 8
-  - node
-notifications:
-  slack:
-    secure: CI3y9riikfzzBEoHWM0482Aj0oFcENm5Hi6z5Lo1pPgwCkY6YcxGaYM54EDCCh8e24IAecVagBE2KEusrcU0F+/zoVJE3QTxr5PRj1AIDvbAW1tMXbz0ckqHnUAW48ox55NNSeaOXxmJ2LNX6t2q5qorf0LnuCRc2OhSOR6PUOM=
-sudo: false

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "LeadConduit integration with TrustedForm",
   "main": "index.js",
   "scripts": {
-    "test": "mocha"
+    "test": "mocha",
+    "test:coverage:lcov": "nyc --reporter=lcov npm test"
   },
   "repository": {
     "type": "git",
@@ -25,6 +26,7 @@
     "leadconduit-types": "^4",
     "mocha": "^4.1.0",
     "nock": "^12.0.3",
+    "nyc": "^15.0.0",
     "timekeeper": "^0.0"
   }
 }


### PR DESCRIPTION
This is the basic replacement of Travis with GH Actions for integrations. I added codecov to the repo as well, but the token needs to be unique per repo.