### PR TITLE
Added logic to change http to https. Small eslint fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
+.vscode
 .idea
 .DS_Store

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org)
 
+## [1.12.5] - 2020-07-01
+### Fixed
+- Now accepts HTTP cert_urls, but makes them into HTTPS
+
 ## [1.12.4] - 2020-06-25
 ### Fixed
 - Now appends the correct certificate token

--- a/lib/claim.js
+++ b/lib/claim.js
@@ -36,7 +36,7 @@ const handle = (vars, callback) => {
 
 };
 
-requestVariables = () => [
+const requestVariables = () => [
   { name: 'lead.trustedform_cert_url', type: 'string', required: true, description: 'TrustedForm Certificate URL' },
   { name: 'trustedform.scan_required_text', type: 'array', required: false, description: 'Required text to search snapshot for' },
   { name: 'trustedform.scan_forbidden_text', type: 'array', required: false, description: 'Forbidden text to search snapshot for' },
@@ -49,9 +49,10 @@ requestVariables = () => [
 ];
 
 const validate = (vars) => {
-  const certUrl = _.get(vars.lead, 'trustedform_cert_url');
+  let certUrl = _.get(vars.lead, 'trustedform_cert_url');
   if (!certUrl) return 'TrustedForm cert URL must not be blank';
-
+  // we accept http requests but want to change them to https
+  certUrl = certUrl.replace('http://', 'https://');
   // example: https://cert.trustedform.com/2605ec3a321e1b3a41addf0bba1213505ef57985
   const tfRegex = /^https:\/\/cert.trustedform.com\/[a-h0-9]{40}/;
   // example: https://cert.trustedform.com/0.YpUzjEEpW3vIkuEJFst4gSDQ7KiFGLZGYkTwIMzRXt8TxcnRUnx3p1U34EWx6KUZ9hyJUuwVm11qoEodrSfsXYDLS7LDFWOyeuCP2MNCHdnAXYkG.IW3iXaUjponmuoB4HNdsWQ.H6cCZ53mOpSXUtUlpdwlWw
@@ -148,7 +149,7 @@ const parseResponse  = (res, body, vars) => {
   return appended;
 };
 
-responseVariables = () => [
+const responseVariables = () => [
   { name: 'outcome', type: 'string', description: 'certificate claim result' },
   { name: 'reason', type: 'string', description: 'in case of failure, the reason for failure' },
   { name: 'user_agent', type: 'string', description: 'Consumer browsers user-agent' },

--- a/lib/claim.js
+++ b/lib/claim.js
@@ -17,6 +17,7 @@ const handle = (vars, callback) => {
     _.compact(vars.lead.trustedform_cert_url.split(','))[0] :
     vars.lead.trustedform_cert_url;
 
+  certUrl = certUrl.replace('http://', 'https://');
 
   let options = {
     cert_url: certUrl,
@@ -51,12 +52,10 @@ const requestVariables = () => [
 const validate = (vars) => {
   let certUrl = _.get(vars.lead, 'trustedform_cert_url');
   if (!certUrl) return 'TrustedForm cert URL must not be blank';
-  // we accept http requests but want to change them to https
-  certUrl = certUrl.replace('http://', 'https://');
   // example: https://cert.trustedform.com/2605ec3a321e1b3a41addf0bba1213505ef57985
-  const tfRegex = /^https:\/\/cert.trustedform.com\/[a-h0-9]{40}/;
+  const tfRegex = /^https?:\/\/cert.trustedform.com\/[a-h0-9]{40}/;
   // example: https://cert.trustedform.com/0.YpUzjEEpW3vIkuEJFst4gSDQ7KiFGLZGYkTwIMzRXt8TxcnRUnx3p1U34EWx6KUZ9hyJUuwVm11qoEodrSfsXYDLS7LDFWOyeuCP2MNCHdnAXYkG.IW3iXaUjponmuoB4HNdsWQ.H6cCZ53mOpSXUtUlpdwlWw
-  const tfFacebookRegex = /^https:\/\/cert.trustedform.com\/0\./;
+  const tfFacebookRegex = /^https?:\/\/cert.trustedform.com\/0\./;
 
   if (!certUrl.match(tfRegex) && !certUrl.match(tfFacebookRegex)) return 'TrustedForm cert URL must be valid';
 };

--- a/lib/claim.js
+++ b/lib/claim.js
@@ -50,7 +50,7 @@ const requestVariables = () => [
 ];
 
 const validate = (vars) => {
-  let certUrl = _.get(vars.lead, 'trustedform_cert_url');
+  const certUrl = _.get(vars.lead, 'trustedform_cert_url');
   if (!certUrl) return 'TrustedForm cert URL must not be blank';
   // example: https://cert.trustedform.com/2605ec3a321e1b3a41addf0bba1213505ef57985
   const tfRegex = /^https?:\/\/cert.trustedform.com\/[a-h0-9]{40}/;

--- a/test/claim_spec.js
+++ b/test/claim_spec.js
@@ -64,7 +64,7 @@ describe('Claim', () => {
 
     const req = baseRequest();
     req.lead.trustedform_cert_url = 'http://cert.trustedform.com/533c80270218239ec3000012';
-    integration.handle(baseRequest(), (err, event) => {
+    integration.handle(req, (err, event) => {
       assert.isNull(err);
       assert.deepEqual(event, expected());
 

--- a/test/claim_spec.js
+++ b/test/claim_spec.js
@@ -1,8 +1,5 @@
 const assert = require('chai').assert;
 const integration = require('../lib/claim');
-const tk = require('timekeeper');
-const emailtype = require('leadconduit-types').email;
-const phonetype = require('leadconduit-types').phone;
 const parser = require('leadconduit-integration').test.types.parser(integration.requestVariables());
 const nock = require('nock');
 
@@ -34,6 +31,11 @@ describe('Cert URL validate', () => {
     assert.isUndefined(error2);
 
   });
+
+  it('should not error when cert url is http', () => {
+    const error = integration.validate({lead: { trustedform_cert_url: 'http://cert.trustedform.com/2605ec3a321e1b3a41addf0bba1213505ef57985' }});
+    assert.isUndefined(error);
+  });
 });
 
 describe('Claim', () => {
@@ -45,6 +47,23 @@ describe('Claim', () => {
       .matchHeader('Authorization', 'Basic WDpjOTM1MWZmNDlhOGUzOGEyMzQ5M2M2YjczMjhjNzYyOQ==')
       .reply(201, standardResponse(), { 'X-Runtime': '0.497349' });
 
+    integration.handle(baseRequest(), (err, event) => {
+      assert.isNull(err);
+      assert.deepEqual(event, expected());
+
+      done();
+    });
+  });
+
+  it('should convert a http cert_url to https', (done) => {
+
+    nock('https://cert.trustedform.com')
+      .post('/533c80270218239ec3000012', 'vendor=Foo%2C%20Inc.')
+      .matchHeader('Authorization', 'Basic WDpjOTM1MWZmNDlhOGUzOGEyMzQ5M2M2YjczMjhjNzYyOQ==')
+      .reply(201, standardResponse(), { 'X-Runtime': '0.497349' });
+
+    const req = baseRequest();
+    req.lead.trustedform_cert_url = 'http://cert.trustedform.com/533c80270218239ec3000012';
     integration.handle(baseRequest(), (err, event) => {
       assert.isNull(err);
       assert.deepEqual(event, expected());
@@ -285,21 +304,21 @@ const facebookResponse = () => {
   return {
     age: 6,
     cert: {
-      cert_id: "0.Ca5p10CcJX-Xez5OHgF5hkp_mNc166yLBQTEOli6gwengwvrGgFVTkD31eCLCMyExX9JnreuobnY063YIPtpk9FF9gFcoZH13q9ooZlNTXEaclhm.qnOgos1woq9gNjKB71dg9A.11EiuZaqmjiScX8GrYbpDG",
-      created_at: "2020-06-22T18:51:40Z"
+      cert_id: '0.Ca5p10CcJX-Xez5OHgF5hkp_mNc166yLBQTEOli6gwengwvrGgFVTkD31eCLCMyExX9JnreuobnY063YIPtpk9FF9gFcoZH13q9ooZlNTXEaclhm.qnOgos1woq9gNjKB71dg9A.11EiuZaqmjiScX8GrYbpDG',
+      created_at: '2020-06-22T18:51:40Z'
     },
-    created_at: "2020-06-22T18:51:46Z",
+    created_at: '2020-06-22T18:51:46Z',
     fingerprints: {
       matching: [],
       non_matching: []
     },
-    id: "0305c844-0f04-4e8e-8179-49692685b0f7",
+    id: '0305c844-0f04-4e8e-8179-49692685b0f7',
     reference: null,
     scans: {
       found: [],
       not_found: []
     },
-    share_url: "https://cert.trustedform.com/0.Ca5p10CcJX-Xez5OHgF5hkp_mNc166yLBQTEOli6gwengwvrGgFVTkD31eCLCMyExX9JnreuobnY063YIPtpk9FF9gFcoZH13q9ooZlNTXEaclhm.qnOgos1woq9gNjKB71dg9A.11EiuZaqmjiScX8GrYbpDG?shared_token=TqIvDcHVbBSlwO3SyiC_uYCB1pz1TJYntf_eHzf4zXvI_Lyqlh641meMMLxEhWKicaoO6rpDS05oigLMgtVYQ4itcbStqMIKkdZ-zVEyXvePZ_RXCVjlYugE1lJrZSebNtKJja7p6DNCy3RTtG4epHjeNApFjSW5DtTC-06zdUFHDuZ94csEjKAKjQGk0P5YL26z7bU2-mQzSaUyTTYebXqYIFvBoicdLhfk60t1awl_0j-_yt5pmB2fuz_G3KTyIG9pApY.wJZzJdLSHW1Wm1pGrVEDRg.C1cS1Vhh3HaKjmo78GALfw",
+    share_url: 'https://cert.trustedform.com/0.Ca5p10CcJX-Xez5OHgF5hkp_mNc166yLBQTEOli6gwengwvrGgFVTkD31eCLCMyExX9JnreuobnY063YIPtpk9FF9gFcoZH13q9ooZlNTXEaclhm.qnOgos1woq9gNjKB71dg9A.11EiuZaqmjiScX8GrYbpDG?shared_token=TqIvDcHVbBSlwO3SyiC_uYCB1pz1TJYntf_eHzf4zXvI_Lyqlh641meMMLxEhWKicaoO6rpDS05oigLMgtVYQ4itcbStqMIKkdZ-zVEyXvePZ_RXCVjlYugE1lJrZSebNtKJja7p6DNCy3RTtG4epHjeNApFjSW5DtTC-06zdUFHDuZ94csEjKAKjQGk0P5YL26z7bU2-mQzSaUyTTYebXqYIFvBoicdLhfk60t1awl_0j-_yt5pmB2fuz_G3KTyIG9pApY.wJZzJdLSHW1Wm1pGrVEDRg.C1cS1Vhh3HaKjmo78GALfw',
     vendor: null,
     warnings: []
   };
@@ -350,10 +369,10 @@ const facebookEvent = () => {
   return {
     age_in_seconds: 6,
     browser: undefined,
-    created_at: "2020-06-22T18:51:40Z",
+    created_at: '2020-06-22T18:51:40Z',
     domain: null,
     duration: undefined,
-    fingerprints_summary: "No Fingerprinting Data",
+    fingerprints_summary: 'No Fingerprinting Data',
     ip: undefined,
     is_masked: undefined,
     location: {
@@ -367,16 +386,16 @@ const facebookEvent = () => {
     },
     masked_cert_url: undefined,
     os: undefined,
-    outcome: "success",
+    outcome: 'success',
     reason: null,
     scans: {
       found: [],
       not_found: [],
     },
-    share_url: "https://cert.trustedform.com/0.Ca5p10CcJX-Xez5OHgF5hkp_mNc166yLBQTEOli6gwengwvrGgFVTkD31eCLCMyExX9JnreuobnY063YIPtpk9FF9gFcoZH13q9ooZlNTXEaclhm.qnOgos1woq9gNjKB71dg9A.11EiuZaqmjiScX8GrYbpDG?shared_token=TqIvDcHVbBSlwO3SyiC_uYCB1pz1TJYntf_eHzf4zXvI_Lyqlh641meMMLxEhWKicaoO6rpDS05oigLMgtVYQ4itcbStqMIKkdZ-zVEyXvePZ_RXCVjlYugE1lJrZSebNtKJja7p6DNCy3RTtG4epHjeNApFjSW5DtTC-06zdUFHDuZ94csEjKAKjQGk0P5YL26z7bU2-mQzSaUyTTYebXqYIFvBoicdLhfk60t1awl_0j-_yt5pmB2fuz_G3KTyIG9pApY.wJZzJdLSHW1Wm1pGrVEDRg.C1cS1Vhh3HaKjmo78GALfw",
+    share_url: 'https://cert.trustedform.com/0.Ca5p10CcJX-Xez5OHgF5hkp_mNc166yLBQTEOli6gwengwvrGgFVTkD31eCLCMyExX9JnreuobnY063YIPtpk9FF9gFcoZH13q9ooZlNTXEaclhm.qnOgos1woq9gNjKB71dg9A.11EiuZaqmjiScX8GrYbpDG?shared_token=TqIvDcHVbBSlwO3SyiC_uYCB1pz1TJYntf_eHzf4zXvI_Lyqlh641meMMLxEhWKicaoO6rpDS05oigLMgtVYQ4itcbStqMIKkdZ-zVEyXvePZ_RXCVjlYugE1lJrZSebNtKJja7p6DNCy3RTtG4epHjeNApFjSW5DtTC-06zdUFHDuZ94csEjKAKjQGk0P5YL26z7bU2-mQzSaUyTTYebXqYIFvBoicdLhfk60t1awl_0j-_yt5pmB2fuz_G3KTyIG9pApY.wJZzJdLSHW1Wm1pGrVEDRg.C1cS1Vhh3HaKjmo78GALfw',
     snapshot_url: undefined,
     time_on_page_in_seconds: null,
-    token: "0.Ca5p10CcJX-Xez5OHgF5hkp_mNc166yLBQTEOli6gwengwvrGgFVTkD31eCLCMyExX9JnreuobnY063YIPtpk9FF9gFcoZH13q9ooZlNTXEaclhm.qnOgos1woq9gNjKB71dg9A.11EiuZaqmjiScX8GrYbpDG",
+    token: '0.Ca5p10CcJX-Xez5OHgF5hkp_mNc166yLBQTEOli6gwengwvrGgFVTkD31eCLCMyExX9JnreuobnY063YIPtpk9FF9gFcoZH13q9ooZlNTXEaclhm.qnOgos1woq9gNjKB71dg9A.11EiuZaqmjiScX8GrYbpDG',
     url: undefined,
     user_agent: undefined,
     warnings: [],


### PR DESCRIPTION
You can find more information [here](https://app.clubhouse.io/active-prospect/story/9290/allow-the-tf-integration-to-accept-http-certificate-urls).

I added some extra logic in the `handle` function to convert from http to https, but I'm open to different approaches too.