### PR TITLE
add support for customizing reference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org)
 
+## [1.14.0] - 2021-03-25
+### Added
+- Added the ability to customize `reference` field in Claim integration
+
 ## [1.13.1] - 2020-11-04
 ### Fixed
 - Added `billable` property to Data Service integration

--- a/lib/claim.js
+++ b/lib/claim.js
@@ -18,7 +18,7 @@ const handle = (vars, callback) => {
   let options = {
     cert_url: certUrl,
     vendor: _.get(vars, 'trustedform.vendor') || vars.source.name,
-    reference: `${host}/events/${vars.lead.id}`,
+    reference: lead.reference || `${host}/events/${vars.lead.id}`,
     required_text: trustedform.scan_required_text,
     forbidden_text: trustedform.scan_forbidden_text,
     email: lead.email,
@@ -43,7 +43,8 @@ const requestVariables = () => [
   { name: 'lead.email', type: 'string', required: false, description: `Lead email that will be fingerprinted, defaults to the lead's "Email" field` },
   { name: 'lead.phone_1', type: 'string', required: false, description: `Lead phone 1 that will be fingerprinted, defaults to the lead's "Phone 1" field` },
   { name: 'lead.phone_2', type: 'string', required: false, description: `Lead phone 2 that will be fingerprinted, defaults to the lead's "Phone 2" field` },
-  { name: 'lead.phone_3', type: 'string', required: false, description: `Lead phone 3 that will be fingerprinted, defaults to the lead's "Phone 3" field` }
+  { name: 'lead.phone_3', type: 'string', required: false, description: `Lead phone 3 that will be fingerprinted, defaults to the lead's "Phone 3" field` },
+  { name: 'lead.reference', type: 'string', required: false, description: `Optional reference, defaults to the lead's url` }
 ];
 
 const parseResponse  = (res, body, vars) => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "leadconduit-trustedform",
-  "version": "1.13.2",
+  "version": "1.14.0",
   "description": "LeadConduit integration with TrustedForm",
   "main": "index.js",
   "scripts": {

--- a/test/claim_spec.js
+++ b/test/claim_spec.js
@@ -24,6 +24,30 @@ describe('Claim', () => {
     });
   });
 
+  it('should pass custom reference if one is present', (done) => {
+
+    nock('https://cert.trustedform.com')
+      .post('/533c80270218239ec3000012', 'reference=https%3A%2F%2Fnext.leadconduit.com%2Fevents%2Flead_id_123%3Femail%3Dtest%40example.com&vendor=Foo%2C%20Inc.')
+      .matchHeader('Authorization', 'Basic WDpjOTM1MWZmNDlhOGUzOGEyMzQ5M2M2YjczMjhjNzYyOQ==')
+      .reply(201, standardResponse(), { 'X-Runtime': '0.497349' });
+
+    const vars = {
+      lead: {
+        id: 'lead_id_123',
+        trustedform_cert_url: 'https://cert.trustedform.com/533c80270218239ec3000012',
+        reference: 'https://next.leadconduit.com/events/lead_id_123?email=test@example.com'
+      }
+    };
+
+    integration.handle(baseRequest(vars), (err, event) => {
+      assert.isNull(err);
+      assert.deepEqual(event, expected());
+
+      done();
+    });
+
+  });
+
   it('should convert a http cert_url to https', (done) => {
 
     nock('https://cert.trustedform.com')


### PR DESCRIPTION
## Description of the change

Adds support for customizing `reference` in claim integration

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change
- [ ] Technical Debt
- [ ] Documentation

## Related tickets

https://app.clubhouse.io/active-prospect/story/20638/allow-for-customization-of-reference-value-through-new-mapping-on-outbound-delivery-step-in-lc

## Checklists

### Development and Testing

- [ ]  Lint rules pass locally.
- [ ]  The code changed/added as part of this pull request has been covered with tests, or this PR does not alter production code.
- [ ]  All tests related to the changed code pass in development, or tests are not applicable.

### Code Review

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.
- [ ]  At least two engineers have been added as "Reviewers" on the pull request.
- [ ]  Changes have been reviewed by at least two other engineers who did not write the code.
- [ ]  This branch has been rebased off master to be current.

### Tracking 
- [ ]  Issue from Clubhouse has a link to this pull request.
- [ ]  This PR has a link to the issue in Clubhouse.

### QA
- [ ]  This branch has been deployed to staging and tested.
