### PR TITLE
add alias integrations for decision service ping and post

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org)
 
+## [1.15.0] - 2021-05-10
+### Added
+- Added aliases for `data_service`: `decision_service_ping` and `decision_service_post` ([ch23031](https://app.clubhouse.io/active-prospect/story/23031/integration-wrappers-for-tfds-in-ac-vc-pricing))
+
 ## [1.14.2] - 2021-04-14
 ### Fixed
 - Added additional error handling to Claim integration 

--- a/docs/outbound.decision_service_ping.md
+++ b/docs/outbound.decision_service_ping.md
@@ -1,0 +1,7 @@
+---
+name: TrustedForm Decision Service Ping
+tag: Data Insights
+integration_type: enhancement marketplace
+link: https://activeprospect.com/products/trustedform/
+---
+TrustedForm Decision Service helps buyers identify the leads that are most likely to convert and effectively manage returns and rejections.

--- a/docs/outbound.decision_service_post.md
+++ b/docs/outbound.decision_service_post.md
@@ -1,0 +1,7 @@
+---
+name: TrustedForm Decision Service Post
+tag: Data Insights
+integration_type: enhancement marketplace
+link: https://activeprospect.com/products/trustedform/
+---
+TrustedForm Decision Service helps buyers identify the leads that are most likely to convert and effectively manage returns and rejections.

--- a/index.js
+++ b/index.js
@@ -2,6 +2,8 @@ module.exports = {
   ui: require('./lib/ui'),
   outbound: {
     claim: require('./lib/claim'),
-    data_service: require('./lib/data_service')
+    data_service: require('./lib/data_service'),
+    decision_service_ping: require('./lib/data_service'),
+    decision_service_post: require('./lib/data_service')
   }
 };


### PR DESCRIPTION
## Description of the change

add alias integrations for decision service ping and post

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change
- [ ] Technical Debt
- [ ] Documentation

## Related tickets

https://app.clubhouse.io/active-prospect/story/23031/integration-wrappers-for-tfds-in-ac-vc-pricing

## Checklists

### Development and Testing

- [ ]  Lint rules pass locally.
- [ ]  The code changed/added as part of this pull request has been covered with tests, or this PR does not alter production code.
- [ ]  All tests related to the changed code pass in development, or tests are not applicable.

### Code Review

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.
- [ ]  At least two engineers have been added as "Reviewers" on the pull request.
- [ ]  Changes have been reviewed by at least two other engineers who did not write the code.
- [ ]  This branch has been rebased off master to be current.

### Tracking 
- [ ]  Issue from Clubhouse has a link to this pull request.
- [ ]  This PR has a link to the issue in Clubhouse.

### QA
- [ ]  This branch has been deployed to staging and tested.
