### PR TITLE
rename data_service 'masked' to 'is_masked'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org)
 
+## [1.16.3] - 2021-11-18
+### Fixed
+- Rename Data Service field `masked` to `is_masked` ([sc-32622](https://app.shortcut.com/active-prospect/story/32622/change-trustedform-data-service-integration-to-return-is-masked-instead-of-masked))
+
 ## [1.16.2] - 2021-11-12
 ### Fixed
 - Fixed to report the same reason on 500 server errors it did before TrustedForm's API change ([sc-25816](https://app.shortcut.com/active-prospect/story/25816/lc-trustedform-integration-is-returning-a-different-error-when-encountering-a-500-system-error))

--- a/lib/data_service.js
+++ b/lib/data_service.js
@@ -96,7 +96,7 @@ const response = (vars, req, res) => {
         user_agent: cert.user_agent,
         fingerprints_matching: get(event, 'fingerprints.matching'),
         fingerprints_non_matching: get(event, 'fingerprints.non_matching'),
-        masked: event.masked,
+        is_masked: event.masked,
         scans_found: found,
         scans_not_found: notFound,
         warnings: event.warnings
@@ -154,7 +154,7 @@ response.variables = () => [
   { name: 'data_service.user_agent', type: 'string', description: 'The browser and operating system for the device on which the consumer filled out the form' },
   { name: 'data_service.fingerprints_matching', type: 'array', description: 'Matching fingerprints that were found on the TrustedForm certificate' },
   { name: 'data_service.fingerprints_non_matching', type: 'array', description: 'Non-matching fingerprints that were found on the TrustedForm certificate' },
-  { name: 'data_service.masked', type: 'boolean', description: 'Whether or not the TrustedForm certificate is masked' },
+  { name: 'data_service.is_masked', type: 'boolean', description: 'Whether or not the TrustedForm certificate is masked' },
   { name: 'data_service.scans_found', type: 'array', description: 'Language that was found through the use of page scanning' },
   { name: 'data_service.scans_not_found', type: 'array', description: 'Language that was not found through the use of page scanning' },
   { name: 'data_service.warnings', type: 'array', description: 'Any warnings present about the content of the form, specific to page scanning and fingerprinting' }

--- a/lib/ui/public/app/fieldData.js
+++ b/lib/ui/public/app/fieldData.js
@@ -95,7 +95,7 @@ module.exports = {
     description: 'Non-matching fingerprints that were found on the TrustedForm certificate.',
     use: 'Reject a lead where there is not a fingerprint match.'
   },
-  masked: {
+  is_masked: {
     description: 'Whether or not the TrustedForm certificate is masked.',
     use: 'Route leads with masked certificates to a different system.'
   },

--- a/test/data_service_spec.js
+++ b/test/data_service_spec.js
@@ -124,7 +124,7 @@ describe('Data Service', () => {
           user_agent: 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.135 Safari/537.36',
           fingerprints_matching: ['test@activeprospect.com'],
           fingerprints_non_matching: ['5122981234'],
-          masked: true,
+          is_masked: true,
           scans_found: ['some disclosure text'],
           scans_not_found: ['other disclosure text'],
           warnings: ['some warning']


### PR DESCRIPTION
## Description of the change

rename data_service 'masked' to 'is_masked' 

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Configuration change
- [ ] Technical Debt
- [ ] Documentation

## Related tickets

https://app.shortcut.com/active-prospect/story/32622/change-trustedform-data-service-integration-to-return-is-masked-instead-of-masked

## Checklists

### Development and Testing

- [x]  Lint rules pass locally.
- [x]  The code changed/added as part of this pull request has been covered with tests, or this PR does not alter production code.
- [x]  All tests related to the changed code pass in development, or tests are not applicable.

### Code Review

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.
- [ ]  At least two engineers have been added as "Reviewers" on the pull request.
- [ ]  Changes have been reviewed by at least two other engineers who did not write the code.
- [ ]  This branch has been rebased off master to be current.

### Tracking 
- [ ]  Issue from Clubhouse has a link to this pull request.
- [ ]  This PR has a link to the issue in Clubhouse.

### QA
- [ ]  This branch has been deployed to staging and tested.
