### PR TITLE
fix to ensure consent ever appends cert data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org)
 
+## [1.17.1] - 2021-12-10
+### Fixed
+- Fixed to ensure `consent` doesn't append cert data, even when present in the response
+
 ## [1.17.0] - 2021-12-10
 ### Added
 - Added new integrations: [consent](https://app.shortcut.com/active-prospect/story/32490/trustedform-consent-integration) & [consent_plus_data](https://app.shortcut.com/active-prospect/story/32491/trustedform-consent-data-integration)

--- a/lib/consent.js
+++ b/lib/consent.js
@@ -88,8 +88,9 @@ const parseResponse = (statusCode, body, vars) => {
       appended.num_required_matched = countRequiredMatched(get(vars, 'trustedform.scan_required_text'), appended.required_scans_found);
     }
 
-    // include cert data, which should only exist on 'consent_plus_data' responses
-    if (event.cert && Object.keys(event.cert).length > 0) {
+    // cert data should only exist on 'consent_plus_data' responses, but only
+    // use it if the plusData flag set by that integration is set
+    if (vars.plusData && event.cert && Object.keys(event.cert).length > 0) {
       Object.assign(appended, parseCertData(event.cert));
     }
   } else {

--- a/lib/consent_plus_data.js
+++ b/lib/consent_plus_data.js
@@ -1,5 +1,10 @@
 const consent = require('./consent');
 
+const handle = (vars, callback) => {
+  vars.plusData = true;
+  consent.handle(vars, callback);
+};
+
 const responseVariables = () => {
   return consent.responseVariables().concat([
     { name: 'age_in_seconds', type: 'number', description: 'Number of seconds since the certificate was created' },
@@ -29,7 +34,7 @@ const responseVariables = () => {
 
 module.exports = {
   validate: consent.validate,
-  handle: consent.handle,
+  handle,
   parseResponse: consent.parseResponse,
   requestVariables: consent.requestVariables,
   responseVariables

--- a/test/consent_spec.js
+++ b/test/consent_spec.js
@@ -84,6 +84,12 @@ describe('Consent (incl. common functionality with Consent + Data)', () => {
       done();
     });
 
+    it('should not parse cert data even if present', (done) => {
+      const parsed = integration.parseResponse(201, consentPlusDataResponse({ plusData: true }), baseRequest());
+      assert.deepEqual(parsed, consentExpected());
+      done();
+    });
+
     it('should parse a failure response', (done) => {
       const expected = consentExpected({
         outcome: 'failure',

--- a/test/consent_spec.js
+++ b/test/consent_spec.js
@@ -122,7 +122,7 @@ describe('Consent (incl. common functionality with Consent + Data)', () => {
 
   describe('Consent + Data response parsing', () => {
     it('should parse additional `cert` data', (done) => {
-      const parsed = integration.parseResponse(201, consentPlusDataResponse(), baseRequest());
+      const parsed = integration.parseResponse(201, consentPlusDataResponse(), baseRequest( { plusData: true }));
       assert.deepEqual(parsed, consentPlusDataExpected());
       done();
     });


### PR DESCRIPTION
## Description of the change

Fixes issue found in QA. The `consent` integration _shouldn't_ ever get the `consent_plus_data` response, but if it somehow does, this fix prevents appending that extra `cert` data to the lead.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change
- [ ] Technical Debt
- [ ] Documentation

## Related tickets

https://app.shortcut.com/active-prospect/story/32490/trustedform-consent-integration

## Checklists

### Development and Testing

- [x]  Lint rules pass locally.
- [x]  The code changed/added as part of this pull request has been covered with tests, or this PR does not alter production code.
- [x]  All tests related to the changed code pass in development, or tests are not applicable.

### Code Review

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.
- [ ]  At least two engineers have been added as "Reviewers" on the pull request.
- [ ]  Changes have been reviewed by at least two other engineers who did not write the code.
- [ ]  This branch has been rebased off master to be current.

### Tracking 
- [ ]  Issue from Clubhouse has a link to this pull request.
- [ ]  This PR has a link to the issue in Clubhouse.

### QA
- [ ]  This branch has been deployed to staging and tested.
