### PR TITLE
use new boolean field names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org)
 
+## [1.17.3] - 2022-02-11
+### Fixed
+- Fixed to use new boolean field names (`is_masked` vs. `masked`, plus `is_mobile` & `is_framed`; [sc-35791](https://app.shortcut.com/active-prospect/story/35791/update-trustedform-consent-consent-data-expected-boolean-response-properties))
+
 ## [1.17.2] - 2021-12-21
 ### Added
 - Added support for `scan_delimiter` parameter ([sc-34085](https://app.shortcut.com/active-prospect/story/34085/add-field-mapping-for-scan-delimiter-to-trustedform-integrations))

--- a/lib/consent.js
+++ b/lib/consent.js
@@ -47,14 +47,14 @@ const parseCertData = (cert) => {
     state: get(cert, 'approx_ip_geo.state'),
     time_zone: get(cert, 'approx_ip_geo.time_zone'),
     browser: get(cert, 'browser.full'),
-    is_mobile: cert.mobile,
+    is_mobile: get(cert, 'is_mobile', cert.mobile),
     os: get(cert, 'operating_system.full'),
     token: cert.cert_id,
     time_on_page_in_seconds: Number.isInteger(cert.event_duration_ms) ? cert.event_duration_ms / 1000 : null,
     created_at: cert.created_at,
     expires_at: cert.expires_at,
     form_input_method: cert.form_input_method,
-    is_framed: cert.framed,
+    is_framed: get(cert, 'is_framed', cert.framed),
     ip: cert.ip,
     kpm: cert.kpm,
     wpm: cert.wpm,
@@ -72,7 +72,7 @@ const parseResponse = (statusCode, body, vars) => {
     appended = {
       outcome: event.outcome || 'success',
       reason: event.reason || null,
-      is_masked: event.masked,
+      is_masked: get(event, 'is_masked', event.masked),
       masked_cert_url: event.masked_cert_url,
       warnings: event.warnings
     };

--- a/test/consent_spec.js
+++ b/test/consent_spec.js
@@ -47,6 +47,15 @@ describe('Consent (incl. common functionality with Consent + Data)', () => {
       done();
     });
 
+    it('should fall back to masked if is_masked not present', (done) => {
+      const response = consentResponse();
+      delete response.is_masked;
+      response.masked = true;
+      const parsed = integration.parseResponse(201, response, baseRequest());
+      assert.equal(parsed.is_masked, true);
+      done();
+    });
+
     it('should parse a success response with scans', (done) => {
       const request = baseRequest({ trustedform: { scan_required_text: ['temperance', 'diligence'] } });
       const scans = {
@@ -161,6 +170,24 @@ describe('Consent (incl. common functionality with Consent + Data)', () => {
       assert.deepEqual(parsed, consentPlusDataExpected());
       done();
     });
+
+    it('should fall back to mobile if is_mobile not present', (done) => {
+      const response = consentPlusDataResponse();
+      delete response.cert.is_mobile;
+      response.cert.mobile = false;
+      const parsed = integration.parseResponse(201, response, baseRequest({ plusData: true }));
+      assert.equal(parsed.is_mobile, false);
+      done();
+    });
+
+    it('should fall back to framed if is_framed not present', (done) => {
+      const response = consentPlusDataResponse();
+      delete response.cert.is_framed;
+      response.cert.framed = true;
+      const parsed = integration.parseResponse(201, response, baseRequest({ plusData: true }));
+      assert.equal(parsed.is_framed, true);
+      done();
+    });
   });
 });
 
@@ -189,7 +216,7 @@ const consentResponse = (override = {}) => {
         '72a34929a612536dde7e56df15ec7278f2ee97ec'
       ]
     },
-    masked: false,
+    is_masked: false,
     masked_cert_url: 'https://cert.trustedform.com/533c80270218239ec3000012',
     outcome: 'success',
     reason: '',
@@ -234,10 +261,10 @@ const consentPlusDataResponse = (override = {}) => {
       event_duration_ms: 20289,
       expires_at: '2021-11-24T17:57:09Z',
       form_input_method: ['typing'],
-      framed: false,
+      is_framed: false,
       ip: '68.203.9.158',
       kpm: 0,
-      mobile: true,
+      is_mobile: true,
       operating_system: {
         full: 'iOS 13.6.1',
         name: 'iOS',


### PR DESCRIPTION
## Description of the change

use new boolean field names

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change
- [ ] Technical Debt
- [ ] Documentation

## Related tickets

https://app.shortcut.com/active-prospect/story/35791/update-trustedform-consent-consent-data-expected-boolean-response-properties

## Checklists

### Development and Testing

- [x]  Lint rules pass locally.
- [x]  The code changed/added as part of this pull request has been covered with tests, or this PR does not alter production code.
- [x]  All tests related to the changed code pass in development, or tests are not applicable.

### Code Review

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.
- [ ]  At least two engineers have been added as "Reviewers" on the pull request.
- [ ]  Changes have been reviewed by at least two other engineers who did not write the code.
- [ ]  This branch has been rebased off master to be current.

### Tracking 
- [ ]  Issue from Shortcut has a link to this pull request.
- [ ]  This PR has a link to the issue in Shortcut.

### QA
- [ ]  This branch has been deployed to staging and tested.
