### PR TITLE
support ping urls in data service integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org)
 
+## [1.18.0] - 2022-03-02
+### Added
+- Added support for `trustedform_ping_url` to the Data Service integration
+
 ## [1.17.2] - 2021-12-21
 ### Added
 - Added support for `scan_delimiter` parameter ([sc-34085](https://app.shortcut.com/active-prospect/story/34085/add-field-mapping-for-scan-delimiter-to-trustedform-integrations))

--- a/lib/data_service.js
+++ b/lib/data_service.js
@@ -5,7 +5,7 @@ const { formatUrl } = require('./helpers');
 const validate = (vars) => {
   if (!process.env.TRUSTEDFORM_DATA_SERVICE_TOKEN) return 'Missing TrustedForm Data Service token';
   const certValidate = require('./helpers').validate;
-  return certValidate(vars);
+  if (certValidate(vars) && !get(vars, 'lead.trustedform_ping_url.valid')) return 'A valid cert URL or ping URL is required';
 };
 
 const request = (vars) => {
@@ -25,7 +25,7 @@ const request = (vars) => {
   body = omitBy(body, (value) => { return isUndefined(value); });
 
   const req = {
-    url: `${formatUrl(lead.trustedform_cert_url)}/peek`,
+    url: `${formatUrl(lead.trustedform_cert_url || lead.trustedform_ping_url.toString())}/peek`,
     method: 'POST',
     body: querystring.stringify(body),
     headers: {
@@ -39,7 +39,8 @@ const request = (vars) => {
 };
 
 request.variables = () => [
-  { name: 'lead.trustedform_cert_url', type: 'string', required: true, description: 'TrustedForm Certificate URL' },
+  { name: 'lead.trustedform_cert_url', type: 'string', required: false, description: 'TrustedForm Certificate URL' },
+  { name: 'lead.trustedform_ping_url', type: 'url', required: false, description: 'TrustedForm Ping URL' },
   { name: 'trustedform.scan_required_text', type: 'array', required: false, description: 'Required text to search snapshot for' },
   { name: 'trustedform.scan_forbidden_text', type: 'array', required: false, description: 'Forbidden text to search snapshot for' },
   { name: 'trustedform.scan_delimiter', type: 'string', required: false, description: 'The character used to surround an asterisk and identify it as a wildcard (default: |)' },


### PR DESCRIPTION
## Description of the change

this change reduces the specificity of skip messages a little, but I think that's unavoidable for this change

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change
- [ ] Technical Debt
- [ ] Documentation

## Related tickets

https://app.shortcut.com/active-prospect/story/36477/allow-ping-urls-to-be-used-instead-of-cert-urls-in-trustedform-data-service

## Checklists

### Development and Testing

- [ ]  Lint rules pass locally.
- [ ]  The code changed/added as part of this pull request has been covered with tests, or this PR does not alter production code.
- [ ]  All tests related to the changed code pass in development, or tests are not applicable.

### Code Review

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.
- [ ]  At least two engineers have been added as "Reviewers" on the pull request.
- [ ]  Changes have been reviewed by at least two other engineers who did not write the code.
- [ ]  This branch has been rebased off master to be current.

### Tracking 
- [ ]  Issue from Shortcut has a link to this pull request.
- [ ]  This PR has a link to the issue in Shortcut.

### QA
- [ ]  This branch has been deployed to staging and tested.
