### PR TITLE
allow TF staging ping URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org)
 
+## [1.18.2] - 2022-03-23
+### Fixed
+- Allow TF staging ping URL in Data Service ([sc-37183](sc-37183/allow-a-trustedform-ping-url-to-be-passed)) 
+
 ## [1.18.1] - 2022-03-12
 ### Fixed
 - Changed Data Service integration to allow TF ping URL passed via `trustedform_cert_url` (& removed `trustedform_ping_url`; [sc-37183](sc-37183/allow-a-trustedform-ping-url-to-be-passed)) 

--- a/lib/data_service.js
+++ b/lib/data_service.js
@@ -7,7 +7,7 @@ const validate = (vars) => {
 
   // accept a TF ping URL here & skip the full cert validation
   const certUrl = get(vars.lead, 'trustedform_cert_url', '');
-  if (certUrl.startsWith('https://ping.trustedform.com')) return;
+  if (certUrl.startsWith('https://ping.trustedform.com') || certUrl.startsWith('https://ping.staging.trustedform.com')) return;
 
   const certValidate = require('./helpers').validate;
   return certValidate(vars);

--- a/test/data_service_spec.js
+++ b/test/data_service_spec.js
@@ -33,6 +33,12 @@ describe('Data Service', () => {
       const error = integration.validate({ lead: { trustedform_cert_url: 'https://ping.trustedform.com/0.whatever' } });
       assert.isUndefined(error);
     });
+
+    it('should pass if staging ping url provided', () => {
+      process.env.TRUSTEDFORM_DATA_SERVICE_TOKEN = 'foo';
+      const error = integration.validate({ lead: { trustedform_cert_url: 'https://ping.staging.trustedform.com/0.whatever' } });
+      assert.isUndefined(error);
+    });
   });
 
   describe('Request', () => {


### PR DESCRIPTION
## Description of the change

allow TF staging ping URL

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change
- [ ] Technical Debt
- [ ] Documentation

## Related tickets

https://app.shortcut.com/active-prospect/story/37183/allow-a-trustedform-ping-url-to-be-passed-in-the-trustedfrom-cert-url-field-of-trustedform-data-service-integration

## Checklists

### Development and Testing

- [x]  Lint rules pass locally.
- [x]  The code changed/added as part of this pull request has been covered with tests, or this PR does not alter production code.
- [x]  All tests related to the changed code pass in development, or tests are not applicable.

### Code Review

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.
- [ ]  At least two engineers have been added as "Reviewers" on the pull request.
- [ ]  Changes have been reviewed by at least two other engineers who did not write the code.
- [ ]  This branch has been rebased off master to be current.

### Tracking 
- [ ]  Issue from Shortcut has a link to this pull request.
- [ ]  This PR has a link to the issue in Shortcut.

### QA
- [ ]  This branch has been deployed to staging and tested.
