### PR TITLE
revert exclusion of TF insights from billable/usages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org)
 
+## [2.0.2] - 2023-01-05
+### Fixed
+- Revert previous change; make insights set `billable` again ([sc-47859](https://app.shortcut.com/active-prospect/story/47859/include-tf-insights-in-usages-results))
+
 ## [2.0.1] - 2022-12-14
 ### Fixed
 - Issue with billable being set in insights ([sc-47158](https://app.shortcut.com/active-prospect/story/47158/tf-insights-missing-from-usages-exclusion-list))

--- a/lib/insights.js
+++ b/lib/insights.js
@@ -63,7 +63,8 @@ const response = (vars, req, res) => {
   } catch (e) {
     return {
         outcome: 'error',
-        reason: 'unable to parse response'
+        reason: 'unable to parse response',
+        billable: 0
     };
   }
   if (res.status === 201) {
@@ -72,6 +73,7 @@ const response = (vars, req, res) => {
 
     const response = {
         outcome: 'success',
+        billable: 1,
         age: event.age,
         browser: cert.browser,
         created_at: cert.created_at,
@@ -108,12 +110,14 @@ const response = (vars, req, res) => {
   } else if (res.status >= 400 && res.status < 500) {
     return {
         outcome: 'failure',
-        reason: get(event, 'errors.detail')
+        reason: get(event, 'errors.detail'),
+        billable: 0
     };
   } else {
     return {
         outcome: 'error',
-        reason: `unknown error (${res.status})`
+        reason: `unknown error (${res.status})`,
+        billable: 0
     };
   }
 };
@@ -121,6 +125,7 @@ const response = (vars, req, res) => {
 response.variables = () => [
   { name: 'outcome', type: 'string', description: 'Integration outcome (success, failure, or error)' },
   { name: 'reason', type: 'string', description: 'in case of failure, the reason for failure' },
+  { name: 'billable', type: 'number', description: 'If the event is billable, the billable count for the event, else 0' },
   { name: 'age', type: 'number', description: 'Number of seconds since the certificate was created' },
   { name: 'browser', type: 'string', description: 'Human friendly version of user-agent' },
   { name: 'consented_at', type: 'time', description: 'Time the user checked the consent language checkbox, in UTC ISO8601 format' },

--- a/test/insights_spec.js
+++ b/test/insights_spec.js
@@ -112,6 +112,7 @@ describe('Insights', () => {
 
       expected = {
           outcome: 'success',
+          billable: 1,
           age: 44,
           browser: 'Chrome 84.0.4147',
           consented_at: '2020-10-19T14:01:43Z',
@@ -179,7 +180,8 @@ describe('Insights', () => {
       };
       const expected = {
           outcome: 'failure',
-          reason: 'cert not found'
+          reason: 'cert not found',
+          billable: 0
       };
       assert.deepEqual(integration.response({}, {}, res), expected);
     });
@@ -191,7 +193,8 @@ describe('Insights', () => {
       };
       const expected = {
           outcome: 'error',
-          reason: 'unable to parse response'
+          reason: 'unable to parse response',
+          billable: 0
       };
       assert.deepEqual(integration.response({}, {}, res), expected);
     });


### PR DESCRIPTION
## Description of the change

revert exclusion of TF insights from billable/usages (i.e., reverts to v2.0.0 functionality)

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change
- [ ] Technical Debt
- [ ] Documentation

## Related tickets

https://app.shortcut.com/active-prospect/story/47859/include-tf-insights-in-usages-results

## Checklists

### Development and Testing

- [ ]  Lint rules pass locally.
- [ ]  The code changed/added as part of this pull request has been covered with tests, or this PR does not alter production code.
- [ ]  All tests related to the changed code pass in development, or tests are not applicable.

### Code Review

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.
- [ ]  At least two engineers have been added as "Reviewers" on the pull request.
- [ ]  Changes have been reviewed by at least two other engineers who did not write the code.
- [ ]  This branch has been rebased off master to be current.

### Tracking 
- [ ]  Issue from Shortcut/Jira has a link to this pull request.
- [ ]  This PR has a link to the issue in Shortcut.

### QA
- [ ]  This branch has been deployed to staging and tested.
