### PR TITLE
Sc 63442/trustedform v4 add verify to add on

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -79,14 +79,24 @@ const tfFacebookRegex = /^https?:\/\/cert.trustedform.com\/0\./;
 const tfStagingRegex = /^https?:\/\/cert.staging.trustedform.com\/([-_a-zA-Z0-9]{40}|[-_a-zA-Z0-9]{80})$/;
 const tfStagingFacebook = /^https?:\/\/cert.staging.trustedform.com\/0\./;
 
+// same as above, for development
+const tfDevelopmentRegex = /^https?:\/\/cert.trustedform-dev.com\/([-_a-zA-Z0-9]{40}|[-_a-zA-Z0-9]{80})$/;
+const tfDevelopmentFacebook = /^https?:\/\/cert.trustedform-dev.com\/0\./;
+
 const validate = (vars) => {
-  const certUrl = _.get(vars.lead, 'trustedform_cert_url');
+  const certUrlRaw = _.get(vars.lead, 'trustedform_cert_url');
+  const certUrl = getUrlString(certUrlRaw);
   if (!certUrl) return 'TrustedForm cert URL must not be blank';
-
   const productionValid = (tfRegex.test(certUrl) || tfFacebookRegex.test(certUrl));
-  const stagingValid = (process.env.NODE_ENV !== 'production' && (tfStagingRegex.test(certUrl) || tfStagingFacebook.test(certUrl)));
+  const developmentValid = (['local','development'].includes(process.env.NODE_ENV) && (tfDevelopmentRegex.test(certUrl) || tfDevelopmentFacebook.test(certUrl)));
+  const stagingValid = (process.env.NODE_ENV === 'staging' && (tfStagingRegex.test(certUrl) || tfStagingFacebook.test(certUrl)));
 
-  if (!productionValid && !stagingValid) return 'TrustedForm cert URL must be valid';
+  console.log('LAKI cert check', process.env.NODE_ENV , certUrl,['local','development'].includes(process.env.NODE_ENV), tfDevelopmentRegex.test(certUrl), tfDevelopmentFacebook.test(certUrl) , developmentValid);
+  if (!productionValid && !stagingValid && !developmentValid) return 'TrustedForm cert URL must be valid';
+};
+
+const getUrlString = (url) => {
+  return typeof url === 'object' ? url.raw : url;
 };
 
 const getLeadConduitUrl = (env = process.env.NODE_ENV) => {

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -87,7 +87,7 @@ const validate = (vars) => {
   const certUrl = _.get(vars.lead, 'trustedform_cert_url');
   if (!certUrl) return 'TrustedForm cert URL must not be blank';
   const productionValid = (tfRegex.test(getUrlString(certUrl)) || tfFacebookRegex.test(getUrlString(certUrl)));
-  const developmentValid = (['local','development'].includes(process.env.NODE_ENV) && (tfDevelopmentRegex.test(getUrlString(certUrl)) || tfDevelopmentFacebook.test(getUrlString(certUrl))));
+  const developmentValid = (process.env.NODE_ENV === 'development' && (tfDevelopmentRegex.test(getUrlString(certUrl)) || tfDevelopmentFacebook.test(getUrlString(certUrl))));
   const stagingValid = (process.env.NODE_ENV === 'staging' && (tfStagingRegex.test(getUrlString(certUrl)) || tfStagingFacebook.test(getUrlString(certUrl))));
 
   if (!productionValid && !stagingValid && !developmentValid) return 'TrustedForm cert URL must be valid';

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -84,14 +84,12 @@ const tfDevelopmentRegex = /^https?:\/\/cert.trustedform-dev.com\/([-_a-zA-Z0-9]
 const tfDevelopmentFacebook = /^https?:\/\/cert.trustedform-dev.com\/0\./;
 
 const validate = (vars) => {
-  const certUrlRaw = _.get(vars.lead, 'trustedform_cert_url');
-  const certUrl = getUrlString(certUrlRaw);
+  const certUrl = _.get(vars.lead, 'trustedform_cert_url');
   if (!certUrl) return 'TrustedForm cert URL must not be blank';
-  const productionValid = (tfRegex.test(certUrl) || tfFacebookRegex.test(certUrl));
-  const developmentValid = (['local','development'].includes(process.env.NODE_ENV) && (tfDevelopmentRegex.test(certUrl) || tfDevelopmentFacebook.test(certUrl)));
-  const stagingValid = (process.env.NODE_ENV === 'staging' && (tfStagingRegex.test(certUrl) || tfStagingFacebook.test(certUrl)));
+  const productionValid = (tfRegex.test(getUrlString(certUrl)) || tfFacebookRegex.test(getUrlString(certUrl)));
+  const developmentValid = (['local','development'].includes(process.env.NODE_ENV) && (tfDevelopmentRegex.test(getUrlString(certUrl)) || tfDevelopmentFacebook.test(getUrlString(certUrl))));
+  const stagingValid = (process.env.NODE_ENV === 'staging' && (tfStagingRegex.test(getUrlString(certUrl)) || tfStagingFacebook.test(getUrlString(certUrl))));
 
-  console.log('LAKI cert check', process.env.NODE_ENV , certUrl,['local','development'].includes(process.env.NODE_ENV), tfDevelopmentRegex.test(certUrl), tfDevelopmentFacebook.test(certUrl) , developmentValid);
   if (!productionValid && !stagingValid && !developmentValid) return 'TrustedForm cert URL must be valid';
 };
 

--- a/lib/trustedform.js
+++ b/lib/trustedform.js
@@ -28,7 +28,6 @@ const request = (vars) => {
       };
     }
   }
-
   if (trustedform.verify.valueOf()) {
     body.verify = {};
   }
@@ -40,7 +39,7 @@ const request = (vars) => {
     headers: {
       'Content-Type': 'application/json',
       'api-version': '4.0',
-      Authorization: `Basic ${Buffer.from(`X:1bf93d760cc4563abb0e5348690691e6`/*${vars.activeprospect.api_key}`*/).toString('base64')}`
+      Authorization: `Basic ${Buffer.from(`X:${vars.activeprospect.api_key}`).toString('base64')}`
     }
   };
 };

--- a/lib/trustedform.js
+++ b/lib/trustedform.js
@@ -19,7 +19,7 @@ const request = (vars) => {
   if (trustedform.insights.valueOf()) {
     body.insights = {
       properties: formatProperties(insights)
-    }
+    };
     if (insights.page_scan?.valueOf()) {
       body.insights.scans = {
         required: trustedform.scan_required_text,
@@ -29,6 +29,10 @@ const request = (vars) => {
     }
   }
 
+  if (trustedform.verify.valueOf()) {
+    body.verify = {};
+  }
+
   return {
     method: 'POST',
     url: lead.trustedform_cert_url.toString(),
@@ -36,9 +40,9 @@ const request = (vars) => {
     headers: {
       'Content-Type': 'application/json',
       'api-version': '4.0',
-      Authorization: `Basic ${Buffer.from(`X:${vars.activeprospect.api_key}`).toString('base64')}`
+      Authorization: `Basic ${Buffer.from(`X:1bf93d760cc4563abb0e5348690691e6`/*${vars.activeprospect.api_key}`*/).toString('base64')}`
     }
-  }
+  };
 };
 
 const formatProperties = (insights) => {
@@ -101,17 +105,22 @@ request.variables = () => [
   { name: 'insights.page_scan', type: 'boolean', required: false, description: 'Request TrustedForm Insights page scan data?' },
   { name: 'trustedform.scan_required_text', type: 'string', required: false, description: 'A list of required text to scan for. TrustedForm will then perform a case and whitespace insensitive search for the string.' },
   { name: 'trustedform.scan_forbidden_text', type: 'string', required: false, description: 'A list of forbidden text to scan for. TrustedForm will then perform a case and whitespace insensitive search for the string.' },
-  { name: 'trustedform.scan_delimiter', type: 'string', required: false, description: 'Use this parameter to designate a delimiter when wrapping wildcards or template variables; defaults to |.' }
+  { name: 'trustedform.scan_delimiter', type: 'string', required: false, description: 'Use this parameter to designate a delimiter when wrapping wildcards or template variables; defaults to |.' },
+  
+  { name: 'trustedform.verify', type: 'boolean', required: true, description: 'If true, a request to the Verify product will be made'}
 ];
 
 const validate = (vars) => {
-  const certError = helpers.validate(vars)
+  const certError = helpers.validate(vars);
   if (certError) return certError;
-  if (!vars.trustedform?.retain?.valueOf() && !vars.trustedform?.insights.valueOf()) return 'a TrustedForm product must be selected';
-  if (!vars.trustedform?.insights?.valueOf() && !(vars.lead.email || vars.lead.phone_1)) return 'an email address or phone number is required to use TrustedForm Retain'
-  if (!vars.trustedform?.retain?.valueOf() && formatProperties(vars.insights).length === 0 && !vars.insights.page_scan?.valueOf()) return 'no properties selected for TrustedForm Insights';
-}
+  if (!hasTrustedFormProduct(vars)) return 'a TrustedForm product must be selected';
+  if (!vars.trustedform?.insights?.valueOf() && !(vars.lead.email || vars.lead.phone_1)) return 'an email address or phone number is required to use TrustedForm Retain';
+  if (!vars.trustedform?.retain?.valueOf() && !vars.trustedform?.verify?.valueOf() && formatProperties(vars.insights).length === 0 && !vars.insights.page_scan?.valueOf()) return 'no properties selected for TrustedForm Insights';
+};
 
+const hasTrustedFormProduct = (vars) => {
+  return vars.trustedform?.retain?.valueOf() || vars.trustedform?.insights?.valueOf() || vars.trustedform?.verify?.valueOf();
+};
 const response = (vars, req, res) => {
   if (res.status < 500) {
     try {
@@ -162,8 +171,12 @@ const response = (vars, req, res) => {
           is_mobile: parsed.insights?.properties?.os?.is_mobile,
           os_name: parsed.insights?.properties?.os?.name,
           page_url: parsed.insights?.properties?.page_url,
-          parent_page_url: parsed.insights?.properties?.parent_page_url
-        }, (v) => { return !isUndefined(v) });
+          parent_page_url: parsed.insights?.properties?.parent_page_url,
+          
+          languages: parsed.insights?.properties?.languages,
+          language_approved: parsed.insights?.properties?.language_approved,
+          success: parsed.verify?.results?.success,
+        }, (v) => { return !isUndefined(v); });
       } else {
         return {
           outcome: parsed.outcome,
@@ -226,11 +239,14 @@ response.variables = () => [
   { name: 'is_mobile', type: 'boolean', description: 'A boolean indicating that the form was filled out on a mobile device or tablet, based on user-agent' },
   { name: 'os_name', type: 'string', description: 'Operating system name' },
   { name: 'page_url', type: 'string', description: 'The URL of the page hosting TrustedForm Certify.' },
-  { name: 'parent_page_url', type: 'string', description: 'The parent URL of the page hosting TrustedForm Certify, if framed.' }
+  { name: 'parent_page_url', type: 'string', description: 'The parent URL of the page hosting TrustedForm Certify, if framed.' },
+  { name: 'verify.languages', type: 'array', description: 'A list of the consent languages detected within the certificate' },
+  { name: 'verify.language_approved', type: 'string', description: 'A boolean indicating if any of the consent languages found have been approved in your account\'s consent language manager.' },
+  { name: 'verify.success', type: 'boolean', description: 'A boolean indicating if any of the consent languages found meet the success criteria defined for your account.' },
 ];
 
 module.exports = {
   request,
   response,
   validate
-}
+};

--- a/lib/ui/api/account.js
+++ b/lib/ui/api/account.js
@@ -23,7 +23,6 @@ module.exports = (req, res) => {
   };
 
   request(options, (err, response, body) => {
-    res.status(200).send(body); /*
     res.status(200).send(body);
     if (err) return res.status(422).send({ error: err.message });
     if (response.statusCode !== 200) {
@@ -38,6 +37,6 @@ module.exports = (req, res) => {
     }
     else {
       res.status(200).send(body);
-    }*/
+    }
   });
 };

--- a/lib/ui/api/account.js
+++ b/lib/ui/api/account.js
@@ -2,7 +2,7 @@ const { get } = require('lodash');
 const request = require('request');
 
 module.exports = (req, res) => {
-  const { apiKey } = { apiKey: '1bf93d760cc4563abb0e5348690691e6' };// req.query;
+  const { apiKey } = req.query;
   if (!apiKey) return res.status(422).send({ error: 'missing required field: apiKey' });
 
   const trustedFormUrl = {

--- a/lib/ui/api/account.js
+++ b/lib/ui/api/account.js
@@ -2,10 +2,16 @@ const { get } = require('lodash');
 const request = require('request');
 
 module.exports = (req, res) => {
-  const { apiKey } = req.query;
+  const { apiKey } = { apiKey: '1bf93d760cc4563abb0e5348690691e6' };// req.query;
   if (!apiKey) return res.status(422).send({ error: 'missing required field: apiKey' });
 
-  const url = get(process, 'env.NODE_ENV') === 'production' ? 'https://app.trustedform.com/account' : 'https://app.staging.trustedform.com/account';
+  const trustedFormUrl = {
+    'production': 'https://app.trustedform.com/account',
+    'staging': 'https://app.staging.trustedform.com/account',
+    'development': 'https://app.trustedform-dev.com/account',
+  };
+  const environment = get(process, 'env.NODE_ENV') || 'development';
+  const url = trustedFormUrl[environment];
 
   const options = {
     url,
@@ -17,6 +23,8 @@ module.exports = (req, res) => {
   };
 
   request(options, (err, response, body) => {
+    res.status(200).send(body); /*
+    res.status(200).send(body);
     if (err) return res.status(422).send({ error: err.message });
     if (response.statusCode !== 200) {
       let message = '';
@@ -30,6 +38,6 @@ module.exports = (req, res) => {
     }
     else {
       res.status(200).send(body);
-    }
+    }*/
   });
 };

--- a/lib/ui/api/account.js
+++ b/lib/ui/api/account.js
@@ -23,7 +23,6 @@ module.exports = (req, res) => {
   };
 
   request(options, (err, response, body) => {
-    res.status(200).send(body);
     if (err) return res.status(422).send({ error: err.message });
     if (response.statusCode !== 200) {
       let message = '';

--- a/lib/ui/api/index.js
+++ b/lib/ui/api/index.js
@@ -5,4 +5,4 @@ const account = require('./account');
 module.exports =
   express.Router()
     .use(json())
-    .use('/account', account)
+    .use('/account', account);

--- a/lib/ui/public/app/config/Page4.vue
+++ b/lib/ui/public/app/config/Page4.vue
@@ -16,6 +16,10 @@
             <input type="checkbox" :disabled="!products.insights.enabled" v-model="products.insights.selected"><span> Insights</span>
             <p class="help-text">TrustedForm Insights helps buyers identify the leads that are most likely to convert and effectively manage returns and rejections.</p>
           </li>
+          <li>
+            <input type="checkbox" :disabled="!products.verify.enabled" v-model="products.verify.selected"><span> Verify</span>
+            <p class="help-text">Confirm that your leads were shown consent language that meets your compliance requirements.</p>
+          </li>
         </ul>
       </form>
     </section>
@@ -23,12 +27,12 @@
       :showPrevious="false"
       :onNext="!showFinish ? next : undefined"
       :onFinish="showFinish ? finish : undefined"
-      :disableNext="!products.retain.selected && !products.insights.selected"
+      :disableNext="!products.retain.selected && !products.insights.selected && !products.verify.selected"
     />
   </div>
 </template>
 <script>
-import { Navigation } from '@activeprospect/integration-components'
+import { Navigation } from '@activeprospect/integration-components';
 
 export default {
   data () {
@@ -42,7 +46,7 @@ export default {
   },
   computed: {
     showFinish () {
-      return this.products.retain.selected && !this.products.insights.selected;
+      return (this.products.retain.selected ||this.products.verify.selected ) && !this.products.insights.selected;
     }
   },
   methods: {
@@ -56,7 +60,7 @@ export default {
     }
   },
   created () {
-    this.$store.dispatch('getProducts')
+    this.$store.dispatch('getProducts');
   }
 };
 </script>

--- a/lib/ui/public/app/store.js
+++ b/lib/ui/public/app/store.js
@@ -16,8 +16,10 @@ const initStore = (config, ui) => new Vuex.Store({
     errors: undefined,
     products: {
       retain: { enabled: false, selected: false },
-      insights: { enabled: false, selected: false }
-    }
+      insights: { enabled: false, selected: false },
+      verify: { enabled: false, selected: false }
+    },
+    filters: []
   },
   mutations: {
     setErrors (state, errors) {
@@ -25,6 +27,10 @@ const initStore = (config, ui) => new Vuex.Store({
     },
     setProduct (state, { product, value }) {
       state.products[product] = value;
+    },
+    setFilters(state, filters) {
+      console.log('LAKI filters', filters);
+      state.filters = filters;
     }
   },
   getters: {
@@ -45,9 +51,14 @@ const initStore = (config, ui) => new Vuex.Store({
         .then(function (response) {
           const availableProducts = [
             'retain',
-            'insights'
-          ]
-          const products = get(response, 'data.product_components');
+            'insights',
+            'verify'
+          ];
+          const products =  [
+            'retain',
+            'insights',
+            'verify'
+          ]; // get(response, 'data.product_components');
           availableProducts.forEach(function (product) {
             context.commit('setProduct', { product, value: {
               enabled: products.includes(product),
@@ -63,7 +74,26 @@ const initStore = (config, ui) => new Vuex.Store({
           }
         });
     },
-    finish (context) {
+    createFilter(context, filterConfig) {
+      const filter = {
+        type: 'filter',
+        reason: filterConfig.reason,
+        outcome: filterConfig.outcome,
+        rule_set: {
+          op: 'and',
+          rules: [{
+            op: filterConfig.rulesOp,
+            lhv: filterConfig.lhv,
+            rhv: filterConfig.rhv
+          }]
+        },
+        description: filterConfig.description,
+        enabled: true
+      };
+      console.log('LAKI filter set', [...context.state.filters, filter]);
+      context.commit('setFilters', [...context.state.filters, filter]);
+    },
+    async finish (context) {
       const { products, v4Fields } = context.state;
       const flow = {
         steps: [{
@@ -76,8 +106,9 @@ const initStore = (config, ui) => new Vuex.Store({
             module_id: config.integration,
             mappings: []
           }
-        }]
+        }],
       };
+      
       if (config.integration === 'leadconduit-trustedform.outbound.trustedform') {
         Object.keys(products).forEach((product) => {
           flow.steps[0].integration.mappings.push({
@@ -91,10 +122,27 @@ const initStore = (config, ui) => new Vuex.Store({
             flow.steps[0].integration.mappings.push({
               property: `insights.${field}`,
               value: v4Fields[field].selected ? 'true' : 'false'
-            })
+            });
           });
         }
+
+        if (products.verify.selected) {
+          console.log('LAKI VERIFY ONSUCCESS');
+          const filterConfig = {
+            reason: 'Trustedform Verify check status is {{trustedform.verify.success}}',
+            rulesOp: 'is equal to',
+            lhv: 'trustedform.outcome',
+            rhv: 'failure',
+            outcome: 'failure',
+            description: 'Filter leads that fail on Trustedform Verify check'
+          };
+          await context.dispatch('createFilter', filterConfig);
+        }
+        context.state.filters.forEach(filter => {
+          flow.steps.push(filter);
+        });      
       }
+      console.log('LAKI', JSON.stringify(flow));
       context.state.ui.create({ flow });
     }
   }

--- a/lib/ui/public/app/store.js
+++ b/lib/ui/public/app/store.js
@@ -53,7 +53,7 @@ const initStore = (config, ui) => new Vuex.Store({
             'insights',
             'verify'
           ];
-          get(response, 'data.product_components');
+          const products =  get(response, 'data.product_components');
           availableProducts.forEach(function (product) {
             context.commit('setProduct', { product, value: {
               enabled: products.includes(product),
@@ -122,10 +122,10 @@ const initStore = (config, ui) => new Vuex.Store({
 
         if (products.verify.selected) {
           const filterConfig = {
-            reason: 'Trustedform Verify check status is {{trustedform.verify.success}}',
-            rulesOp: 'is equal to',
+            reason: '{{trustedform.reason}}',
+            rulesOp: 'is not equal to',
             lhv: 'trustedform.outcome',
-            rhv: 'failure',
+            rhv: 'success',
             outcome: 'failure',
             description: 'Filter leads that fail on Trustedform Verify check'
           };

--- a/lib/ui/public/app/store.js
+++ b/lib/ui/public/app/store.js
@@ -53,11 +53,7 @@ const initStore = (config, ui) => new Vuex.Store({
             'insights',
             'verify'
           ];
-          const products =  [
-            'retain',
-            'insights',
-            'verify'
-          ]; // get(response, 'data.product_components');
+          get(response, 'data.product_components');
           availableProducts.forEach(function (product) {
             context.commit('setProduct', { product, value: {
               enabled: products.includes(product),

--- a/lib/ui/public/app/store.js
+++ b/lib/ui/public/app/store.js
@@ -29,7 +29,6 @@ const initStore = (config, ui) => new Vuex.Store({
       state.products[product] = value;
     },
     setFilters(state, filters) {
-      console.log('LAKI filters', filters);
       state.filters = filters;
     }
   },
@@ -90,7 +89,6 @@ const initStore = (config, ui) => new Vuex.Store({
         description: filterConfig.description,
         enabled: true
       };
-      console.log('LAKI filter set', [...context.state.filters, filter]);
       context.commit('setFilters', [...context.state.filters, filter]);
     },
     async finish (context) {
@@ -127,7 +125,6 @@ const initStore = (config, ui) => new Vuex.Store({
         }
 
         if (products.verify.selected) {
-          console.log('LAKI VERIFY ONSUCCESS');
           const filterConfig = {
             reason: 'Trustedform Verify check status is {{trustedform.verify.success}}',
             rulesOp: 'is equal to',
@@ -142,7 +139,6 @@ const initStore = (config, ui) => new Vuex.Store({
           flow.steps.push(filter);
         });      
       }
-      console.log('LAKI', JSON.stringify(flow));
       context.state.ui.create({ flow });
     }
   }

--- a/lib/ui/public/app/v4fields.js
+++ b/lib/ui/public/app/v4fields.js
@@ -93,5 +93,5 @@ module.exports = {
     name: 'Time On Page',
     description: 'The amount of time, in seconds, that the consumer spent on the page during the lead event.',
     enabled: false
-  }
-}
+  },
+};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "leadconduit-trustedform",
-  "version": "2.1.1",
+  "version": "2.2.1",
   "description": "LeadConduit integration with TrustedForm",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "leadconduit-trustedform",
-  "version": "2.2.1",
+  "version": "2.1.1",
   "description": "LeadConduit integration with TrustedForm",
   "main": "index.js",
   "scripts": {

--- a/test/helper_spec.js
+++ b/test/helper_spec.js
@@ -116,6 +116,21 @@ describe('Helper functions', () => {
       assert.isUndefined(error);
     });
 
+    it('should accept development certs on development', () => {
+      process.env.NODE_ENV = 'development';
+      const error = helper.validate({ lead: { trustedform_cert_url: 'http://cert.trustedform-dev.com/2605ec3a321e1b3a41addf0bba1213505ef57985' } });
+      assert.isUndefined(error);
+    });
+
+    it('should not accept invalid certs on development', () => {
+      process.env.NODE_ENV = 'development';
+      const error = helper.validate({ lead: { trustedform_cert_url: 'http://someothersite.com' } });
+      assert.equal(error, 'TrustedForm cert URL must be valid');
+
+      const error2 = helper.validate({ lead: { trustedform_cert_url: 'KOWABUNGAhttps://cert.trustedform.com/' } });
+      assert.equal(error2, 'TrustedForm cert URL must be valid');
+    });
+    
     it('should accept staging certs on staging', () => {
       process.env.NODE_ENV = 'staging';
       const error = helper.validate({ lead: { trustedform_cert_url: 'http://cert.staging.trustedform.com/2605ec3a321e1b3a41addf0bba1213505ef57985' } });
@@ -133,6 +148,11 @@ describe('Helper functions', () => {
 
     it('should not accept staging certs on production', () => {
       const error = helper.validate({ lead: { trustedform_cert_url: 'http://cert.staging.trustedform.com/2605ec3a321e1b3a41addf0bba1213505ef57985' } });
+      assert.equal(error, 'TrustedForm cert URL must be valid');
+    });
+
+    it('should not accept development certs on production', () => {
+      const error = helper.validate({ lead: { trustedform_cert_url: 'http://cert.trustedform-dev.com/2605ec3a321e1b3a41addf0bba1213505ef57985' } });
       assert.equal(error, 'TrustedForm cert URL must be valid');
     });
 

--- a/test/trustedform_spec.js
+++ b/test/trustedform_spec.js
@@ -14,7 +14,8 @@ describe('v4', () => {
       assert.equal(integration.validate(baseVars({
         trustedform: {
           retain: false,
-          insights: false
+          insights: false,
+          verify: false
         }
       })), 'a TrustedForm product must be selected');
     });
@@ -30,7 +31,7 @@ describe('v4', () => {
 
     it('should require at least one property selected for insights', () => {
       let vars = baseVars({
-        trustedform: { retain: 'false' },
+        trustedform: { retain: 'false', verify: 'false' },
         insights: { age: 'false', domain: 'false', location: 'false'}}
       );
       assert.equal(integration.validate(vars), 'no properties selected for TrustedForm Insights');
@@ -38,7 +39,7 @@ describe('v4', () => {
   });
 
   describe('request', () => {
-    it('should correctly format a request with both insights and retain queries', () => {
+    it('should correctly format a request with all queries (insights, retain and verify)', () => {
       const expected = {
         method: 'POST',
         url: 'https://cert.trustedform.com/2605ec3a321e1b3a41addf0bba1213505ef57985',
@@ -72,7 +73,8 @@ describe('v4', () => {
               'parent_page_url',
               'seconds_on_page'
             ]
-          }
+          },
+          verify: {}
         }),
         headers: {
           'Content-Type': 'application/json',
@@ -115,6 +117,7 @@ describe('v4', () => {
       const vars = baseVars({
         trustedform: {
           insights: 'false',
+          verify: 'false',
           vendor: 'ABC, Inc.',
           custom_reference: '9876'
         }
@@ -135,10 +138,23 @@ describe('v4', () => {
       const vars = baseVars({
         trustedform: {
           retain: 'false',
+          verify: 'false',
           scan_required_text: 'click here!'
         },
         insights: {
           page_scan: 'true'
+        }
+      });
+      assert.deepEqual(integration.request(vars).body, expected);
+    });
+    it('should correctly format a verify only request', () => {
+      const expected = JSON.stringify({
+        verify: {}
+      });
+      const vars = baseVars({
+        trustedform: {
+          retain: 'false',
+          insights: 'false'
         }
       });
       assert.deepEqual(integration.request(vars).body, expected);
@@ -275,7 +291,7 @@ describe('v4', () => {
         time_on_page_in_seconds: 8374,
         time_zone: 'America/Chicago',
         vendor: 'Inbound Verbose'
-      }
+      };
       assert.deepEqual(integration.response({}, {}, res), expected);
     });
 
@@ -344,7 +360,8 @@ const baseVars = (custom) => {
     },
     trustedform: {
       retain: 'true',
-      insights: 'true'
+      insights: 'true',
+      verify: 'true'
     },
     insights: {
       age: 'true',


### PR DESCRIPTION
## Description of the change

Added support for the Trustedform Verify function.

- When processing a Lead, the add-on will send the verify key along with the payload when validating the Trustedform certificate.
- A filter will be created and for any result with an outcome other than success, the flow will be stopped and a failure will be responded to the source.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change
- [ ] Technical Debt
- [ ] Documentation

## Related tickets

> [Ticket SC-63442 TrustedForm v4 - Add Verify to Add-On](https://app.shortcut.com/active-prospect/story/63442/trustedform-v4-add-verify-to-add-on)

## Checklists

### Development and Testing

- [ ]  Lint rules pass locally.
- [X]  The code changed/added as part of this pull request has been covered with tests, or this PR does not alter production code.
- [X]  All tests related to the changed code pass in development, or tests are not applicable.

### Code Review

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.
- [ ]  At least two engineers have been added as "Reviewers" on the pull request.
- [ ]  Changes have been reviewed by at least two other engineers who did not write the code.
- [ ]  This branch has been rebased off master to be current.

### Tracking 
- [ ]  Issue from Shortcut/Jira has a link to this pull request.
- [ ]  This PR has a link to the issue in Shortcut.

### QA
- [ ]  This branch has been deployed to staging and tested.
