### PR TITLE
Scan request variables should be typed as arrays

### DIFF
--- a/lib/trustedform.js
+++ b/lib/trustedform.js
@@ -102,10 +102,10 @@ request.variables = () => [
   { name: 'insights.time_on_page', type: 'boolean', required: false, description: 'Request TrustedForm Insights time on page data?' },
   { name: 'insights.page_url', type: 'boolean', required: false, description: 'Request TrustedForm Insights page URL data?' },
   { name: 'insights.page_scan', type: 'boolean', required: false, description: 'Request TrustedForm Insights page scan data?' },
-  { name: 'trustedform.scan_required_text', type: 'string', required: false, description: 'A list of required text to scan for. TrustedForm will then perform a case and whitespace insensitive search for the string.' },
-  { name: 'trustedform.scan_forbidden_text', type: 'string', required: false, description: 'A list of forbidden text to scan for. TrustedForm will then perform a case and whitespace insensitive search for the string.' },
+  { name: 'trustedform.scan_required_text', type: 'array', required: false, description: 'A list of required text to scan for. TrustedForm will then perform a case and whitespace insensitive search for the string.' },
+  { name: 'trustedform.scan_forbidden_text', type: 'array', required: false, description: 'A list of forbidden text to scan for. TrustedForm will then perform a case and whitespace insensitive search for the string.' },
   { name: 'trustedform.scan_delimiter', type: 'string', required: false, description: 'Use this parameter to designate a delimiter when wrapping wildcards or template variables; defaults to |.' },
-  
+
   { name: 'trustedform.verify', type: 'boolean', required: true, description: 'If true, a request to the Verify product will be made'}
 ];
 
@@ -171,7 +171,7 @@ const response = (vars, req, res) => {
           os_name: parsed.insights?.properties?.os?.name,
           page_url: parsed.insights?.properties?.page_url,
           parent_page_url: parsed.insights?.properties?.parent_page_url,
-          
+
           languages: parsed.insights?.properties?.languages,
           language_approved: parsed.insights?.properties?.language_approved,
           success: parsed.verify?.results?.success,


### PR DESCRIPTION
This bug makes it impossible to use the 4.0 insights scan feature in this integration. 

## Description of the change

Change the request variable types to `array`.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change
- [ ] Technical Debt
- [ ] Documentation

## Related tickets

HOTFIX

## Checklists

### Development and Testing

- [x]  Lint rules pass locally.
- [x]  The code changed/added as part of this pull request has been covered with tests, or this PR does not alter production code.
- [x]  All tests related to the changed code pass in development, or tests are not applicable.

### Code Review

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.
- [ ]  At least two engineers have been added as "Reviewers" on the pull request.
- [ ]  Changes have been reviewed by at least two other engineers who did not write the code.
- [ ]  This branch has been rebased off master to be current.

### Tracking 
- [ ]  Issue from Shortcut/Jira has a link to this pull request.
- [ ]  This PR has a link to the issue in Shortcut.

### QA
- [ ]  This branch has been deployed to staging and tested.
