### PR TITLE
Sc 65226/Handle missing Insights mappings in `validate`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,34 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org)
 
+## [2.3.1] - 2024-01-10
+### Fixed
+- v4 `validate` function will properly handle missing `insights` vars ([sc-65226](https://app.shortcut.com/active-prospect/story/65226/trustedform-v4-insights-add-on-with-no-field-mappings-errors-in-validation))
+
+## [2.3.0] - 2023-11-20
+### Fixed
+- Re-add fixed TrustedForm v4 Verify Add-On ([#105](https://github.com/activeprospect/leadconduit-integration-trustedform/pull/105), [sc-63442](https://app.shortcut.com/active-prospect/story/63442/trustedform-v4-add-verify-to-add-on))
+
+## [2.2.2] - 2023-11-17
+### Fixed
+- Revert [#102](https://github.com/activeprospect/leadconduit-integration-trustedform/pull/102)
+
+## [2.2.1] - 2023-11-17
+### Fixed
+- Page scan variables are now typed as arrays ([#103](https://github.com/activeprospect/leadconduit-integration-trustedform/pull/103))
+
+## [2.2.0] - 2023-11-15
+### Added
+- TrustedForm v4 Verify Add-On ([sc-63442](https://app.shortcut.com/active-prospect/story/63442/trustedform-v4-add-verify-to-add-on))
+
+## [2.1.1] - 2023-07-14
+### Fixed
+- Updated "Age" and "Age in Seconds" description for TF Inisights and TF Consent + Insights ([sc-48650](https://app.shortcut.com/active-prospect/story/48650/incorrect-description-for-age-in-the-trustedform-enhancements))
+
+## [2.1.0] - 2023-06-20
+### Added
+- TrustedForm v4 Integration ([sc-50245](https://app.shortcut.com/active-prospect/story/50245/trustedform-v4-new-integration-trustedform))
+
 ## [2.0.3] - 2023-02-21
 ### Fixed
 - `domain` data is now appended if returned as part of insights data

--- a/lib/claim.js
+++ b/lib/claim.js
@@ -34,6 +34,7 @@ const requestVariables = () => [
   { name: 'lead.phone_3', type: 'string', required: false, description: 'Lead phone 3 that will be fingerprinted, defaults to the lead\'s "Phone 3" field' }
 ];
 
+// eslint-disable-next-line complexity
 const parseResponse = (res, body, vars) => {
   let appended = {};
   const event = body;

--- a/lib/consent.js
+++ b/lib/consent.js
@@ -64,6 +64,7 @@ const parseCertData = (cert) => {
   };
 };
 
+// eslint-disable-next-line complexity
 const parseResponse = (statusCode, body, vars) => {
   let appended = {};
   const event = body;

--- a/lib/trustedform.js
+++ b/lib/trustedform.js
@@ -67,7 +67,7 @@ const formatProperties = (insights) => {
   ];
 
   let selectedProps = insightsProps.map((field) => {
-    if (insights[field.mapping]?.valueOf()) return field.value;
+    if (insights?.[field.mapping]?.valueOf()) return field.value;
   });
 
   return compact(selectedProps);
@@ -113,8 +113,8 @@ const validate = (vars) => {
   const certError = helpers.validate(vars);
   if (certError) return certError;
   if (!hasTrustedFormProduct(vars)) return 'a TrustedForm product must be selected';
-  if (!vars.trustedform?.insights?.valueOf() && !(vars.lead.email || vars.lead.phone_1)) return 'an email address or phone number is required to use TrustedForm Retain';
-  if (!vars.trustedform?.retain?.valueOf() && !vars.trustedform?.verify?.valueOf() && formatProperties(vars.insights).length === 0 && !vars.insights.page_scan?.valueOf()) return 'no properties selected for TrustedForm Insights';
+  if (vars.trustedform?.retain?.valueOf() && !(vars.lead.email || vars.lead.phone_1)) return 'an email address or phone number is required to use TrustedForm Retain';
+  if (vars.trustedform?.insights?.valueOf() && formatProperties(vars.insights).length === 0 && !vars.insights?.page_scan?.valueOf()) return 'no properties selected for TrustedForm Insights';
 };
 
 const hasTrustedFormProduct = (vars) => {

--- a/lib/trustedform.js
+++ b/lib/trustedform.js
@@ -113,13 +113,18 @@ const validate = (vars) => {
   const certError = helpers.validate(vars);
   if (certError) return certError;
   if (!hasTrustedFormProduct(vars)) return 'a TrustedForm product must be selected';
-  if (vars.trustedform?.retain?.valueOf() && !(vars.lead.email || vars.lead.phone_1)) return 'an email address or phone number is required to use TrustedForm Retain';
-  if (vars.trustedform?.insights?.valueOf() && formatProperties(vars.insights).length === 0 && !vars.insights?.page_scan?.valueOf()) return 'no properties selected for TrustedForm Insights';
+  if (retainEnabled(vars) && !hasRequiredRetainProps(vars)) return 'an email address or phone number is required to use TrustedForm Retain';
+  if (insightsEnabled(vars) && !hasAtLeastOneInsightsProp(vars)) return 'no properties selected for TrustedForm Insights';
 };
 
-const hasTrustedFormProduct = (vars) => {
-  return vars.trustedform?.retain?.valueOf() || vars.trustedform?.insights?.valueOf() || vars.trustedform?.verify?.valueOf();
-};
+const hasTrustedFormProduct = (vars) => retainEnabled(vars) || insightsEnabled(vars) || verifyEnabled(vars);
+const retainEnabled = (vars) => vars.trustedform?.retain?.valueOf();
+const insightsEnabled = (vars) => vars.trustedform?.insights?.valueOf();
+const verifyEnabled = (vars) => vars.trustedform?.verify?.valueOf();
+const hasRequiredRetainProps = (vars) => !!(vars.lead.email || vars.lead.phone_1);
+const hasAtLeastOneInsightsProp = (vars) => formatProperties(vars.insights).length > 0 || vars.insights?.page_scan?.valueOf();
+
+
 const response = (vars, req, res) => {
   if (res.status < 500) {
     try {


### PR DESCRIPTION
## Description of the change

1. Fix insights vars check in case vars.insights is completely missing
2. Fix validations for Retain and Insights so they apply regardless of other products selected

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change
- [ ] Technical Debt
- [ ] Documentation

## Related tickets

https://app.shortcut.com/active-prospect/story/65226/trustedform-v4-insights-add-on-with-no-field-mappings-errors-in-validation

## Checklists

### Development and Testing

- [x]  Lint rules pass locally.
- [x]  The code changed/added as part of this pull request has been covered with tests, or this PR does not alter production code.
- [x]  All tests related to the changed code pass in development, or tests are not applicable.

Tested locally. With this configuration

<img width="1382" alt="Screenshot 2024-01-10 at 5 09 37 PM" src="https://github.com/activeprospect/leadconduit-integration-trustedform/assets/8379268/d088b960-7b3a-47dd-ad27-7620861cd65b">

I got this result

<img width="906" alt="Screenshot 2024-01-10 at 5 09 29 PM" src="https://github.com/activeprospect/leadconduit-integration-trustedform/assets/8379268/2b9a1bda-dbb0-421a-a55c-69e21fab442a">

### Code Review

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.
- [ ]  At least two engineers have been added as "Reviewers" on the pull request.
- [ ]  Changes have been reviewed by at least two other engineers who did not write the code.
- [ ]  This branch has been rebased off master to be current.

### Tracking 
- [ ]  Issue from Shortcut/Jira has a link to this pull request.
- [ ]  This PR has a link to the issue in Shortcut.

### QA
- [ ]  This branch has been deployed to staging and tested.
