### PR TITLE
[Sc 65261] Prompt user for PageScan terms when PageScan is selected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This project adheres to [Semantic Versioning](http://semver.org)
 ## [2.3.3] - 2024-02-05
 ### Added
 - added `amount_required_matched` field to v4 integration for requests with required scans ([sc-65371](https://app.shortcut.com/active-prospect/story/65371/trustedform-v4-page-scan-rule-improvements))
+- PageScan required/forbidden text configuration screen. ([sc-65261](https://app.shortcut.com/active-prospect/story/65261/trustedform-v4-insights-add-on-ui-should-prompt-for-required-and-forbidden-scan-text))
+- Add notice when account has no TF products available ([sc-67604](https://app.shortcut.com/active-prospect/story/67604/trustedform-v4-fix-add-on-ui-to-handle-no-products))
 
 ## [2.3.2] - 2024-01-19
 ### Fixed

--- a/lib/ui/public/app/config/Page5.vue
+++ b/lib/ui/public/app/config/Page5.vue
@@ -75,6 +75,10 @@ export default {
     },
     confirm () {
       this.$store.state.v4Fields = this.fields;
+      if (this.fields.page_scan?.selected) {
+        this.$router.push('/6')
+        return
+      }
       this.$store.dispatch('confirm');
     }
   },

--- a/lib/ui/public/app/config/Page6.vue
+++ b/lib/ui/public/app/config/Page6.vue
@@ -1,0 +1,46 @@
+<template>
+  <div>
+    <header>
+      Configure TrustedForm Insights
+    </header>
+    <section>
+      <h3>Page Scan Forbidden/Required Text</h3>
+      <p>Please set your required and/or forbidden text for the TrustedForm set in LeadConduit; the step will fail if the required term is missing and if the forbidden term is present in the page.</p>
+      <Form v-model="values.value" @submit="handleSubmit" legend="Select Field">
+        <SelectField
+          name="pagescan"
+          :options="taggable.value"
+          taggable
+          multiple
+          @tag="handleTag"
+        ></SelectField>
+      </Form>
+    </section>
+    <Navigation
+      :onConfirm="confirm"
+      :disableConfirm="taggable.length === 0"
+    />
+  </div>
+</template>
+<script setup>
+import { Navigation } from '@activeprospect/integration-components';
+import { SelectField, Form } from '@activeprospect/ui-components';
+import { toRaw, ref } from 'vue';
+import { useStore } from 'vuex';
+
+const store = useStore();
+const values = ref({});
+const taggable = ref([]);
+
+function handleTag(tag) {
+  console.log({tag, taggable: toRaw(taggable)})
+}
+
+function handleSubmit() {
+  console.log('submit', toRaw(values), toRaw(taggable))
+}
+
+function confirm() {
+  store.dispatch('confirm'); 
+}
+</script>

--- a/lib/ui/public/app/config/Page6.vue
+++ b/lib/ui/public/app/config/Page6.vue
@@ -6,10 +6,10 @@
     <section>
       <h3>Page Scan Forbidden/Required Text</h3>
       <p>Please set your required and/or forbidden text for the TrustedForm set in LeadConduit; the step will fail if the required term is missing and if the forbidden term is present in the page.</p>
-      <Form v-model="values.value" @submit="handleSubmit" legend="Select Field">
+      <Form v-model="values" @submit="handleSubmit" legend="Select Field">
         <SelectField
           name="pagescan"
-          :options="taggable.value"
+          :options="taggable"
           taggable
           multiple
           @tag="handleTag"

--- a/lib/ui/public/app/config/Page6.vue
+++ b/lib/ui/public/app/config/Page6.vue
@@ -6,41 +6,73 @@
     <section>
       <h3>Page Scan Forbidden/Required Text</h3>
       <p>Please set your required and/or forbidden text for the TrustedForm set in LeadConduit; the step will fail if the required term is missing and if the forbidden term is present in the page.</p>
-      <Form v-model="values" @submit="handleSubmit" legend="Select Field">
+      <Form :actions="false">
         <SelectField
-          name="pagescan"
-          :options="taggable"
+          name="PageScan Required"
+          v-model="requiredTags"
+          :options="requiredOptions"
           taggable
           multiple
-          @tag="handleTag"
+          @tag="handleRequiredTag"
+          openDirection="bottom"
+        ></SelectField>
+
+        <SelectField
+          name="PageScan Forbidden"
+          v-model="forbiddenTags"
+          :options="forbiddenOptions"
+          taggable
+          multiple
+          @tag="handleForbiddenTag"
+          openDirection="bottom"
         ></SelectField>
       </Form>
     </section>
     <Navigation
       :onConfirm="confirm"
-      :disableConfirm="taggable.length === 0"
+      :disableConfirm="false"
     />
   </div>
 </template>
+
 <script setup>
 import { Navigation } from '@activeprospect/integration-components';
 import { SelectField, Form } from '@activeprospect/ui-components';
-import { toRaw, ref } from 'vue';
+import { ref } from 'vue';
 import { useStore } from 'vuex';
 
 const store = useStore();
-const values = ref({});
-const taggable = ref([]);
+const requiredTags = ref([]);
+const requiredOptions = ref([]);
+const forbiddenTags = ref([]);
+const forbiddenOptions = ref([]);
 
-function handleTag(tag) {
-  console.log({tag, taggable: toRaw(taggable)})
+function handleRequiredTag(tag) {
+  requiredTags.value.push(tag);
+  requiredOptions.value.push(tag);
 }
 
-function handleSubmit() {
-  console.log('submit', toRaw(values), toRaw(taggable))
+function handleForbiddenTag(tag) {
+  forbiddenTags.value.push(tag);
+  forbiddenOptions.value.push(tag);
 }
 
 function confirm() {
+  store.commit('setPageScan', {
+    required: requiredTags.value,
+    forbidden: forbiddenTags.value
+  });
   store.dispatch('confirm'); 
 }
 </script>
+
+<style scoped>
+/** override this style https://github.com/activeprospect/leadconduit-client/blob/a005d3ac5627aa39d12c64756561ef400b512bf3/public/css/core/forms.styl#L252-L254 */
+:deep(input[type="text"]) {
+  min-width: 0 !important;
+}
+
+:deep(.formkit-outer) {
+  width: 100%;
+}
+</style>

--- a/lib/ui/public/app/config/Page6.vue
+++ b/lib/ui/public/app/config/Page6.vue
@@ -39,34 +39,45 @@
   </div>
 </template>
 
-<script setup>
+<script>
 import { Navigation } from '@activeprospect/integration-components';
 import { SelectField, Form } from '@activeprospect/ui-components';
-import { ref } from 'vue';
-import { useStore } from 'vuex';
 
-const store = useStore();
-const requiredTags = ref([]);
-const requiredOptions = ref([]);
-const forbiddenTags = ref([]);
-const forbiddenOptions = ref([]);
-
-function handleRequiredTag(tag) {
-  requiredTags.value.push(tag);
-  requiredOptions.value.push(tag);
-}
-
-function handleForbiddenTag(tag) {
-  forbiddenTags.value.push(tag);
-  forbiddenOptions.value.push(tag);
-}
-
-function confirm() {
-  store.commit('setPageScan', {
-    required: requiredTags.value,
-    forbidden: forbiddenTags.value
-  });
-  store.dispatch('confirm'); 
+export default {
+  components: {
+    Navigation,
+    SelectField,
+    Form
+  },
+  data() {
+    return {
+      /** @type {string[]} */
+      requiredTags: [],
+      /** @type {string[]} */
+      requiredOptions: [],
+      /** @type {string[]} */
+      forbiddenTags: [],
+      /** @type {string[]} */
+      forbiddenOptions: [],
+    }
+  },
+  methods: {
+    handleRequiredTag(tag) {
+      this.requiredTags.push(tag);
+      this.requiredOptions.push(tag);
+    },
+    handleForbiddenTag(tag) {
+      this.forbiddenTags.push(tag);
+      this.forbiddenOptions.push(tag);
+    },
+    confirm() {
+      this.$store.commit('setPageScan', {
+        required: this.requiredTags,
+        forbidden: this.forbiddenTags
+      });
+      this.$store.dispatch('confirm'); 
+    },
+  }
 }
 </script>
 

--- a/lib/ui/public/app/config/Page6.vue
+++ b/lib/ui/public/app/config/Page6.vue
@@ -5,7 +5,11 @@
     </header>
     <section>
       <h3>Page Scan Forbidden/Required Text</h3>
-      <p>Please set your required and/or forbidden text for the TrustedForm set in LeadConduit; the step will fail if the required term is missing and if the forbidden term is present in the page.</p>
+      <p>
+        Please set your required and/or forbidden text for the TrustedForm set in LeadConduit;
+        the step will fail if the required term is missing and if the forbidden term is present in the page.
+        <a href="https://community.activeprospect.com/posts/4078890">Learn More</a>
+      </p>
       <Form :actions="false">
         <SelectField
           name="PageScan Required"
@@ -67,6 +71,8 @@ function confirm() {
 </script>
 
 <style scoped>
+/* All the selectors here use `:deep()` because otherwise the styles can't be scoped, since the classes are added by a library. */
+
 /** override this style https://github.com/activeprospect/leadconduit-client/blob/a005d3ac5627aa39d12c64756561ef400b512bf3/public/css/core/forms.styl#L252-L254 */
 :deep(input[type="text"]) {
   min-width: 0 !important;

--- a/lib/ui/public/app/index.js
+++ b/lib/ui/public/app/index.js
@@ -3,12 +3,14 @@ import { createApp } from 'vue';
 import Config from './config/Config.vue';
 import initStore from './store';
 import router from './router';
+import { plugin } from '@activeprospect/ui-components';
 
 function init (config) {
   const app = createApp(Config);
 
   app.use(initStore(config, ui));
   app.use(router);
+  app.use(plugin);
 
   app.mount('#app');
 }

--- a/lib/ui/public/app/router.js
+++ b/lib/ui/public/app/router.js
@@ -5,6 +5,7 @@ import PageTwo from './config/Page2.vue';
 import PageThree from './config/Page3.vue';
 import PageFour from './config/Page4.vue';
 import PageFive from './config/Page5.vue';
+import PageSix from './config/Page6.vue';
 
 export default createRouter({
   history: createMemoryHistory(),
@@ -39,6 +40,11 @@ export default createRouter({
           path: '5',
           name: 'PageFive',
           component: PageFive
+        },
+        {
+          path: '6',
+          name: 'PageSix',
+          component: PageSix
         }
       ]
     }

--- a/lib/ui/public/app/store.js
+++ b/lib/ui/public/app/store.js
@@ -2,7 +2,7 @@ import { createStore } from 'vuex';
 import fieldData from './fieldData';
 import v4Fields from './v4fields';
 import axios from 'axios';
-import { get } from 'lodash';
+import { castArray, get } from 'lodash';
 import { toRaw } from 'vue';
 
 const initStore = (config, ui) => createStore({
@@ -20,7 +20,9 @@ const initStore = (config, ui) => createStore({
       insights: { enabled: false, selected: false },
       verify: { enabled: false, selected: false }
     },
-    filters: []
+    filters: [],
+    pageScanForbidden: [],
+    pageScanRequired: [],
   },
   mutations: {
     setErrors (state, errors) {
@@ -31,6 +33,10 @@ const initStore = (config, ui) => createStore({
     },
     setFilters(state, filters) {
       state.filters = filters;
+    },
+    setPageScan(state, { required, forbidden }) {
+      state.pageScanRequired = required;
+      state.pageScanForbidden = forbidden;
     }
   },
   getters: {
@@ -89,7 +95,7 @@ const initStore = (config, ui) => createStore({
       context.commit('setFilters', [...context.state.filters, filter]);
     },
     async confirm (context) {
-      const { products, v4Fields } = context.state;
+      const { products, v4Fields, pageScanForbidden, pageScanRequired } = context.state;
       const flow = {
         steps: [{
           type: 'recipient',
@@ -118,6 +124,20 @@ const initStore = (config, ui) => createStore({
               property: `insights.${field}`,
               value: v4Fields[field].selected ? 'true' : 'false'
             });
+          });
+        }
+
+        if (castArray(pageScanRequired).length > 0) {
+          flow.steps[0].integration.mappings.push({
+            property: 'trustedform.scan_required_text',
+            value: toRaw(pageScanRequired)
+          });
+        }
+
+        if (castArray(pageScanForbidden).length > 0) {
+          flow.steps[0].integration.mappings.push({
+            property: 'trustedform.scan_forbidden_text',
+            value: toRaw(pageScanForbidden)
           });
         }
 


### PR DESCRIPTION
## Description of the change

1. If `PageScan` is selected, the user will be directed to a new page where they configure their required/forbidden page scan terms. I chose to make this page option (i.e. the user can "continue" without entering anything) because that's the way it currently works and I don't exactly see a problem with it, if someone wants to enable PageScan but not configure any terms. 🤷🏻 

There are screen recordings of the UX attached to the ticket

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change
- [ ] Technical Debt
- [ ] Documentation

## Related tickets

https://app.shortcut.com/active-prospect/story/65261/trustedform-v4-insights-add-on-ui-should-prompt-for-required-and-forbidden-scan-text

## Checklists

### Development and Testing

- [x]  Lint rules pass locally.
- [N/A]  The code changed/added as part of this pull request has been covered with tests, or this PR does not alter production code. (N/A because there are not Vue tests in this integration and it didn't feel like it was in scope to do so here.
- [x]  All tests related to the changed code pass in development, or tests are not applicable.

### Code Review

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.
- [ ]  At least two engineers have been added as "Reviewers" on the pull request.
- [ ]  Changes have been reviewed by at least two other engineers who did not write the code.
- [ ]  This branch has been rebased off master to be current.

### Tracking 
- [ ]  Issue from Shortcut/Jira has a link to this pull request.
- [ ]  This PR has a link to the issue in Shortcut.

### QA
- [ ]  This branch has been deployed to staging and tested.
