### PR TITLE
Fix external link: `target="_blank"`

### DIFF
--- a/lib/ui/public/app/config/Page4.vue
+++ b/lib/ui/public/app/config/Page4.vue
@@ -9,7 +9,7 @@
     <section v-else-if="!productsAvailable">
       <p>
         Your account does not have access to TrustedForm. Please contact
-        <a href="mailto:support@activeprospect.com">support@activeprospect.com</a>
+        <a href="mailto:support@activeprospect.com" target="_blank">support@activeprospect.com</a>
         if this is in error or if you would like to add TrustedForm to your account.
       </p>
     </section>

--- a/lib/ui/public/app/config/Page6.vue
+++ b/lib/ui/public/app/config/Page6.vue
@@ -8,7 +8,7 @@
       <p>
         Please set your required and/or forbidden text for the TrustedForm set in LeadConduit;
         the step will fail if the required term is missing and if the forbidden term is present in the page.
-        <a href="https://community.activeprospect.com/posts/4078890">Learn More</a>
+        <a href="https://community.activeprospect.com/posts/4078890" target="_blank">Learn More</a>
       </p>
       <Form :actions="false">
         <SelectField


### PR DESCRIPTION
## Description of the change

I botched a couple links. Also TIL that Chrome treats `mailto` links differently when `target="_blank"`.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change
- [ ] Technical Debt
- [ ] Documentation

## Related tickets

https://app.shortcut.com/active-prospect/story/65261/trustedform-v4-insights-add-on-ui-should-prompt-for-required-and-forbidden-scan-text#activity-68580

https://app.shortcut.com/active-prospect/story/67604/trustedform-v4-fix-add-on-ui-to-handle-no-products#activity-68578

## Checklists

### Development and Testing

- [x]  Lint rules pass locally.
- [x]  The code changed/added as part of this pull request has been covered with tests, or this PR does not alter production code.
- [x]  All tests related to the changed code pass in development, or tests are not applicable.

### Code Review

- [x]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.
- [ ]  At least two engineers have been added as "Reviewers" on the pull request.
- [ ]  Changes have been reviewed by at least two other engineers who did not write the code.
- [ ]  This branch has been rebased off master to be current.

### Tracking 
- [ ]  Issue from Shortcut/Jira has a link to this pull request.
- [ ]  This PR has a link to the issue in Shortcut.

### QA
- [ ]  This branch has been deployed to staging and tested.
