### PR TITLE
fix UI loading for old TF integrations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org)
 
+## [2.3.5] - 2024-02-22
+### Fixed
+- fixed the loading screen an issue causing perpetual loading screens for old TF integrations ([sc-68876](https://app.shortcut.com/active-prospect/story/68876/leadconduit-trustedform-consent-integration-ui-issue))
+
+## [2.3.4] - 2024-02-13
+### Fixed
+- fixed broken links in the RUI
+
 ## [2.3.3] - 2024-02-05
 ### Added
 - added `amount_required_matched` field to v4 integration for requests with required scans ([sc-65371](https://app.shortcut.com/active-prospect/story/65371/trustedform-v4-page-scan-rule-improvements))

--- a/lib/ui/public/app/config/Page1.vue
+++ b/lib/ui/public/app/config/Page1.vue
@@ -19,7 +19,7 @@
       <Navigation :onConfirm="onConfirm"/>
     </div>
     <div v-else-if="!isDataService">
-      <LoadingScreen :onFinish="() => {/* NOOP */}" :module-name="'TrustedForm ' + moduleName"/>
+      <LoadingScreen :onFinish="finish" :module-name="'TrustedForm ' + moduleName"/>
     </div>
   </div>
 </template>
@@ -55,6 +55,9 @@ export default {
   methods: {
     onConfirm () {
       this.$router.push('/2');
+    },
+    finish () {
+      this.$store.dispatch('confirm');
     }
   },
   mounted () {

--- a/lib/ui/public/app/config/Page1.vue
+++ b/lib/ui/public/app/config/Page1.vue
@@ -63,7 +63,7 @@ export default {
   mounted () {
     const { integration } = this.$store.state.config;
     if (integration.includes('outbound.trustedform')) this.$router.push('/4');
-    if (!integration.includes('insights')) {
+    else if (!integration.includes('insights')) {
       this.isDataService = false;
     }
   }


### PR DESCRIPTION
## Description of the change

This updates the loading spinner that is shown for integrations other than Insights and v4 so that it closes and creates the step after 2s have passed

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change
- [ ] Technical Debt
- [ ] Documentation

## Related tickets

https://app.shortcut.com/active-prospect/story/68876/leadconduit-trustedform-consent-integration-ui-issue

## Checklists

### Development and Testing

- [ ]  Lint rules pass locally.
- [ ]  The code changed/added as part of this pull request has been covered with tests, or this PR does not alter production code.
- [ ]  All tests related to the changed code pass in development, or tests are not applicable.

### Code Review

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.
- [ ]  At least two engineers have been added as "Reviewers" on the pull request.
- [ ]  Changes have been reviewed by at least two other engineers who did not write the code.
- [ ]  This branch has been rebased off master to be current.

### Tracking 
- [ ]  Issue from Shortcut/Jira has a link to this pull request.
- [ ]  This PR has a link to the issue in Shortcut.

### QA
- [ ]  This branch has been deployed to staging and tested.
