### PR TITLE
add support for masked_cert_url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org)
 
+## [2.3.6] - 2024-03-12
+### Fixed
+- v4 integration now appends `masked_cert_url` when present
+
 ## [2.3.5] - 2024-02-22
 ### Fixed
 - fixed the loading screen an issue causing perpetual loading screens for old TF integrations ([sc-68876](https://app.shortcut.com/active-prospect/story/68876/leadconduit-trustedform-consent-integration-ui-issue))

--- a/lib/trustedform.js
+++ b/lib/trustedform.js
@@ -144,6 +144,7 @@ const response = (vars, req, res) => {
 
           previously_retained: parsed.retain?.results?.previously_retained,
           expires_at: parsed.retain?.results?.expires_at || parsed.insights?.properties?.expires_at,
+          masked_cert_url: parsed.retain?.results?.masked_cert_url,
 
           scans_result: parsed.insights?.scans?.result?.success,
           required_scans_found: parsed.insights?.scans?.result?.required?.found,
@@ -219,6 +220,7 @@ response.variables = () => [
   { name: 'vendor', type: 'string', description: 'The parameter provided in the request, intended to be the name of the company that provided the lead associated with the certificate.' },
   { name: 'previously_retained', type: 'boolean', description: 'A boolean indicating whether your account had already retained this certificate.' },
   { name: 'expires_at', type: 'time', description: 'The UTC ISO8601 formatted date and time when this certificate will no longer be available for API requests.' },
+  { name: 'masked_cert_url', type: 'url', description: 'The certificate url that masks the lead source url and snapshot' },
   { name: 'scans_result', type: 'boolean', description: 'A boolean indicating if all required text was found and none of the forbidden text was found.' },
   { name: 'required_scans_found', type: 'array', description: 'A list of required scan terms that were found in the recorded content.' },
   { name: 'required_scans_not_found', type: 'array', description: 'A list of required scan terms that were not found in the recorded content.' },

--- a/test/trustedform_spec.js
+++ b/test/trustedform_spec.js
@@ -373,7 +373,8 @@ describe('v4', () => {
             reference: 'https://app.leadconduit-development.com/events/647916a0d2c7c9de31fffd13',
             results: {
               expires_at: '2023-08-29T20:43:31Z',
-              previously_retained: true
+              previously_retained: true,
+              masked_cert_url: 'https://cert.trustedform-dev.com/f1fd052c43f08078a37d840b243daa69a35e8eda'
             },
             vendor: 'Inbound Verbose'
           }
@@ -399,6 +400,7 @@ describe('v4', () => {
         kpm: 212.38938053097348,
         latitude: 30.2627,
         longitude: -97.7467,
+        masked_cert_url: 'https://cert.trustedform-dev.com/f1fd052c43f08078a37d840b243daa69a35e8eda',
         matched_email: 'superman@activeprospect.com',
         os_full: 'Mac OS X 10.15',
         os_name: 'Mac OS X',


### PR DESCRIPTION
## Description of the change

adds `masked_cert_url` as a response variable for the v4 integration

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change
- [ ] Technical Debt
- [ ] Documentation

## Related tickets

https://app.shortcut.com/active-prospect/story/69416/trustedform-v4-0-add-on-not-appending-masked-certificate-url

## Checklists

### Development and Testing

- [ ]  Lint rules pass locally.
- [ ]  The code changed/added as part of this pull request has been covered with tests, or this PR does not alter production code.
- [ ]  All tests related to the changed code pass in development, or tests are not applicable.

### Code Review

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.
- [ ]  At least two engineers have been added as "Reviewers" on the pull request.
- [ ]  Changes have been reviewed by at least two other engineers who did not write the code.
- [ ]  This branch has been rebased off master to be current.

### Tracking 
- [ ]  Issue from Shortcut/Jira has a link to this pull request.
- [ ]  This PR has a link to the issue in Shortcut.

### QA
- [ ]  This branch has been deployed to staging and tested.
