### PR TITLE
add custom api key support to v4 integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org)
 
+## [2.4.0] - 2024-04-10
+### Added
+- v4 integration now supports optional api key mapping
+
 ## [2.3.6] - 2024-03-12
 ### Fixed
 - v4 integration now appends `masked_cert_url` when present

--- a/lib/trustedform.js
+++ b/lib/trustedform.js
@@ -39,7 +39,7 @@ const request = (vars) => {
     headers: {
       'Content-Type': 'application/json',
       'api-version': '4.0',
-      Authorization: `Basic ${Buffer.from(`X:${vars.activeprospect.api_key}`).toString('base64')}`
+      Authorization: `Basic ${Buffer.from(`X:${trustedform.api_key || vars.activeprospect.api_key}`).toString('base64')}`
     }
   };
 };
@@ -77,6 +77,7 @@ request.variables = () => [
   { name: 'lead.trustedform_cert_url', type: 'trustedform_url', required: true, description: 'TrustedForm Certificate URL' },
   { name: 'lead.email', type: 'string', required: false, description: `The email of the consumer you believe was recorded in the certificate; defaults to the lead's "Email" field.` },
   { name: 'lead.phone_1', type: 'string', required: false, description: `The phone number of the consumer you believe was recorded in the certificate; defaults to the lead's "Phone 1" field.`},
+  { name: 'trustedform.api_key', type: 'string', required: false, description: 'Optional TrustedForm API key. Used for claiming certs that belong to another account' },
 
   { name: 'trustedform.retain', type: 'boolean', required: true, description: 'If true, a request to the Retain product will be made' },
   { name: 'trustedform.custom_reference', type: 'string', required: false, description: `Any text that may help you identify the lead associated with the certificate, such as a unique lead identifier or URL pointing to the lead in another system; defaults to the lead's url.` },

--- a/test/trustedform_spec.js
+++ b/test/trustedform_spec.js
@@ -288,6 +288,16 @@ describe('v4', () => {
     });
   });
 
+  it('should use a custom api key when present', () => {
+    const expected = `Basic ${Buffer.from('X:abcd').toString('base64')}`;
+    const vars = baseVars({
+      trustedform: {
+        api_key: 'abcd'
+      }
+    });
+    assert.equal(integration.request(vars).headers.Authorization, expected);
+  });
+
   describe('response', () => {
     it('should correctly handle a success response', () => {
       const res = {


### PR DESCRIPTION
## Description of the change

adds an optional API key mapping to the v4 integration

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change
- [ ] Technical Debt
- [ ] Documentation

## Related tickets

https://app.shortcut.com/active-prospect/story/69418/trustedform-v4-add-support-for-api-key-mapping

## Checklists

### Development and Testing

- [ ]  Lint rules pass locally.
- [ ]  The code changed/added as part of this pull request has been covered with tests, or this PR does not alter production code.
- [ ]  All tests related to the changed code pass in development, or tests are not applicable.

### Code Review

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.
- [ ]  At least two engineers have been added as "Reviewers" on the pull request.
- [ ]  Changes have been reviewed by at least two other engineers who did not write the code.
- [ ]  This branch has been rebased off master to be current.

### Tracking 
- [ ]  Issue from Shortcut/Jira has a link to this pull request.
- [ ]  This PR has a link to the issue in Shortcut.

### QA
- [ ]  This branch has been deployed to staging and tested.
