### PR TITLE
Sc 77184/trustedform v4 verify add 1 1 consent check

### DIFF
--- a/lib/trustedform.js
+++ b/lib/trustedform.js
@@ -266,7 +266,7 @@ response.variables = () => [
   { name: 'os_name', type: 'string', description: 'Operating system name' },
   { name: 'page_url', type: 'string', description: 'The URL of the page hosting TrustedForm Certify.' },
   { name: 'parent_page_url', type: 'string', description: 'The parent URL of the page hosting TrustedForm Certify, if framed.' },
-  { name: 'one_to_one', type: 'boolean', description: 'A boolean indicating if the cert structure satisfied the requirements for 1:1 consent., and is available to use in filters' },
+  { name: 'one_to_one', type: 'boolean', description: 'A boolean indicating if the cert structure satisfied the requirements for 1:1 consent.' },
   { name: 'verify.languages', type: 'array', description: 'A list of the consent languages detected within the certificate' },
   { name: 'verify.language_approved', type: 'boolean', description: 'A boolean indicating if any of the consent languages found have been approved in your account\'s consent language manager.' },
   { name: 'verify.success', type: 'boolean', description: 'A boolean indicating if any of the consent languages found meet the success criteria defined for your account.' },

--- a/lib/trustedform.js
+++ b/lib/trustedform.js
@@ -28,8 +28,10 @@ const request = (vars) => {
       };
     }
   }
+
   if (trustedform.verify?.valueOf()) {
-    body.verify = {};
+    const advertiserName = trustedform?.advertiser_name;
+    body.verify = pickBy({ advertiser_name: advertiserName }, (v) => { return !isUndefined(v); });
   }
 
   return {
@@ -108,7 +110,7 @@ request.variables = () => [
   { name: 'trustedform.scan_delimiter', type: 'string', required: false, description: 'Use this parameter to designate a delimiter when wrapping wildcards or template variables; defaults to |.' },
 
   { name: 'trustedform.verify', type: 'boolean', required: true, description: 'If true, a request to the Verify product will be made'},
-  { name: 'verify.advertiser_name', type: 'string', required: false, description: 'The name of the legal entity for an advertiser that will be used to determine if they were given consent in a one to one manner.' }
+  { name: 'trustedform.advertiser_name', type: 'string', required: false, description: 'The name of the legal entity for an advertiser that will be used to determine if they were given consent in a one to one manner. This value will be normalized to be case insensitive, ignore redundant white space and omit non ascii characters. Both \'Acme Inc.\' and \'acme inc\' would result in the same processed value.' }
 ];
 
 const validate = (vars) => {
@@ -134,13 +136,13 @@ const response = (vars, req, res) => {
     try {
       const parsed = JSON.parse(res.body);
       if (res.status === 200) {
-        const verify = hasVerifyData(parsed) ? 
-        pickBy({
-          languages: parsed.verify.languages.map(lang => lang.text),
-          language_approved: parsed.verify.result.language_approved,
-          success: parsed.verify.result.success,
-          one_to_one: parsed.verify.result.one_to_one
-        },  (v) => { return !isUndefined(v); }) : undefined;
+        const verify = hasVerifyData(parsed) 
+          ? pickBy({
+              languages: parsed.verify.languages.map(lang => lang.text),
+              language_approved: parsed.verify.result.language_approved,
+              success: parsed.verify.result.success,
+            }, (v) => !isUndefined(v)) 
+          : undefined; 
           
         const appended = pickBy({
           outcome: parsed.outcome,
@@ -189,6 +191,7 @@ const response = (vars, req, res) => {
           os_name: parsed.insights?.properties?.os?.name,
           page_url: parsed.insights?.properties?.page_url,
           parent_page_url: parsed.insights?.properties?.parent_page_url,
+          one_to_one: parsed.verify?.result?.one_to_one,
           verify
         }, (v) => { return !isUndefined(v); });
         // only include this property if page scan was selected
@@ -263,10 +266,10 @@ response.variables = () => [
   { name: 'os_name', type: 'string', description: 'Operating system name' },
   { name: 'page_url', type: 'string', description: 'The URL of the page hosting TrustedForm Certify.' },
   { name: 'parent_page_url', type: 'string', description: 'The parent URL of the page hosting TrustedForm Certify, if framed.' },
+  { name: 'one_to_one', type: 'boolean', description: 'A boolean indicating if the cert structure satisfied the requirements for 1:1 consent., and is available to use in filters' },
   { name: 'verify.languages', type: 'array', description: 'A list of the consent languages detected within the certificate' },
   { name: 'verify.language_approved', type: 'boolean', description: 'A boolean indicating if any of the consent languages found have been approved in your account\'s consent language manager.' },
   { name: 'verify.success', type: 'boolean', description: 'A boolean indicating if any of the consent languages found meet the success criteria defined for your account.' },
-  { name: 'verify.one_to_one', type: 'boolean', description: 'A boolean indicating if the consent was given in a one to one manner.' }
 ];
 
 module.exports = {

--- a/lib/trustedform.js
+++ b/lib/trustedform.js
@@ -1,6 +1,5 @@
-const { get } = require('lodash');
 const helpers = require('./helpers');
-const { compact, pickBy, isUndefined } = require('lodash');
+const { compact, get, pickBy, isUndefined } = require('lodash');
 
 const request = (vars) => {
   const { lead, trustedform, insights } = vars;
@@ -108,7 +107,8 @@ request.variables = () => [
   { name: 'trustedform.scan_forbidden_text', type: 'array', required: false, description: 'A list of forbidden text to scan for. TrustedForm will then perform a case and whitespace insensitive search for the string.' },
   { name: 'trustedform.scan_delimiter', type: 'string', required: false, description: 'Use this parameter to designate a delimiter when wrapping wildcards or template variables; defaults to |.' },
 
-  { name: 'trustedform.verify', type: 'boolean', required: true, description: 'If true, a request to the Verify product will be made'}
+  { name: 'trustedform.verify', type: 'boolean', required: true, description: 'If true, a request to the Verify product will be made'},
+  { name: 'verify.advertiser_name', type: 'string', required: false, description: 'The name of the legal entity for an advertiser that will be used to determine if they were given consent in a one to one manner.' }
 ];
 
 const validate = (vars) => {
@@ -126,7 +126,7 @@ const verifyEnabled = (vars) => vars.trustedform?.verify?.valueOf();
 const hasRequiredRetainProps = (vars) => !!(vars.lead.email || vars.lead.phone_1);
 const hasAtLeastOneInsightsProp = (vars) => formatProperties(vars.insights).length > 0 || vars.insights?.page_scan?.valueOf();
 const hasVerifyData = (data) => {
-  return data.verify?.languages || data.verify?.result?.language_approved || data.verify?.result?.success;
+  return data.verify?.languages || data.verify?.result?.language_approved || data.verify?.result?.success || data.verify?.result?.one_to_one;
 };
 
 const response = (vars, req, res) => {
@@ -135,11 +135,12 @@ const response = (vars, req, res) => {
       const parsed = JSON.parse(res.body);
       if (res.status === 200) {
         const verify = hasVerifyData(parsed) ? 
-          { 
-            languages: parsed.verify.languages.map(lang => lang.text),
-            language_approved: parsed.verify.result.language_approved,
-            success: parsed.verify.result.success
-          } : undefined;
+        pickBy({
+          languages: parsed.verify.languages.map(lang => lang.text),
+          language_approved: parsed.verify.result.language_approved,
+          success: parsed.verify.result.success,
+          one_to_one: parsed.verify.result.one_to_one
+        },  (v) => { return !isUndefined(v); }) : undefined;
           
         const appended = pickBy({
           outcome: parsed.outcome,
@@ -265,6 +266,7 @@ response.variables = () => [
   { name: 'verify.languages', type: 'array', description: 'A list of the consent languages detected within the certificate' },
   { name: 'verify.language_approved', type: 'boolean', description: 'A boolean indicating if any of the consent languages found have been approved in your account\'s consent language manager.' },
   { name: 'verify.success', type: 'boolean', description: 'A boolean indicating if any of the consent languages found meet the success criteria defined for your account.' },
+  { name: 'verify.one_to_one', type: 'boolean', description: 'A boolean indicating if the consent was given in a one to one manner.' }
 ];
 
 module.exports = {

--- a/lib/ui/public/app/config/Page1.vue
+++ b/lib/ui/public/app/config/Page1.vue
@@ -62,7 +62,9 @@ export default {
   },
   mounted () {
     const { integration } = this.$store.state.config;
-    if (integration.includes('outbound.trustedform')) this.$router.push('/4');
+    if (integration.includes('outbound.trustedform')) { 
+      this.$router.push('/4');
+    }
     else if (!integration.includes('insights')) {
       this.isDataService = false;
     }

--- a/lib/ui/public/app/config/Page4.vue
+++ b/lib/ui/public/app/config/Page4.vue
@@ -68,8 +68,9 @@ export default {
   methods: {
     confirm () {
       this.$store.state.products = this.products;
-      if (this.products.insights.selected) {
-        this.$router.push('/5');
+      if (this.products.insights.selected || this.products.verify.selected) {
+        this.products.insights.selected && this.$router.push('/5');
+        this.products.verify.selected && this.$router.push('/6');
       } else {
         this.$store.dispatch('confirm');
       }

--- a/lib/ui/public/app/config/Page4.vue
+++ b/lib/ui/public/app/config/Page4.vue
@@ -64,7 +64,7 @@ export default {
   },
   computed: {
     productsAvailable() {
-      return true // LAKI this.products.retain.enabled || this.products.insights.enabled || this.products.verify.enabled;
+      return this.products.retain.enabled || this.products.insights.enabled || this.products.verify.enabled;
     }
   },
   methods: {

--- a/lib/ui/public/app/config/Page4.vue
+++ b/lib/ui/public/app/config/Page4.vue
@@ -70,7 +70,7 @@ export default {
       this.$store.state.products = this.products;
       if (this.products.insights.selected && this.products.verify.selected) {
         this.$router.push('/5'); 
-        this.$store.dispatch('setShouldConfigVerify', true);
+        this.$store.commit('setShouldConfigVerify', true);
       } else if (this.products.insights.selected) {
         this.$router.push('/5');
       } else if (this.products.verify.selected) {

--- a/lib/ui/public/app/config/Page4.vue
+++ b/lib/ui/public/app/config/Page4.vue
@@ -62,7 +62,7 @@ export default {
   },
   computed: {
     productsAvailable() {
-      return true // this.products.retain.enabled || this.products.insights.enabled || this.products.verify.enabled;
+      return this.products.retain.enabled || this.products.insights.enabled || this.products.verify.enabled;
     }
   },
   methods: {

--- a/lib/ui/public/app/config/Page4.vue
+++ b/lib/ui/public/app/config/Page4.vue
@@ -78,7 +78,7 @@ export default {
       } else {
         this.$store.dispatch('confirm');
       }
-}
+    }
   },
   async created () {
     await this.$store.dispatch('getProducts');

--- a/lib/ui/public/app/config/Page4.vue
+++ b/lib/ui/public/app/config/Page4.vue
@@ -62,19 +62,23 @@ export default {
   },
   computed: {
     productsAvailable() {
-      return this.products.retain.enabled || this.products.insights.enabled || this.products.verify.enabled;
+      return true // this.products.retain.enabled || this.products.insights.enabled || this.products.verify.enabled;
     }
   },
   methods: {
     confirm () {
       this.$store.state.products = this.products;
-      if (this.products.insights.selected || this.products.verify.selected) {
-        this.products.insights.selected && this.$router.push('/5');
-        this.products.verify.selected && this.$router.push('/6');
+      if (this.products.insights.selected && this.products.verify.selected) {
+        this.$router.push('/5'); 
+        this.$store.dispatch('setShouldConfigVerify', true);
+      } else if (this.products.insights.selected) {
+        this.$router.push('/5');
+      } else if (this.products.verify.selected) {
+        this.$router.push('/7');
       } else {
         this.$store.dispatch('confirm');
       }
-    }
+}
   },
   async created () {
     await this.$store.dispatch('getProducts');

--- a/lib/ui/public/app/config/Page4.vue
+++ b/lib/ui/public/app/config/Page4.vue
@@ -43,6 +43,7 @@
       :showPrevious="false"
       :onConfirm="confirm"
       :disableConfirm="!products.retain.selected && !products.insights.selected && !products.verify.selected"
+      :navHistory="navHistory"
     />
   </div>
 </template>
@@ -54,7 +55,8 @@ export default {
     return {
       loading: true,
       products: this.$store.getters.getProducts,
-      errors: this.$store.getters.getErrors
+      errors: this.$store.getters.getErrors,
+      navHistory: this.$store.getters.getNavHistory
     };
   },
   components: {
@@ -62,16 +64,19 @@ export default {
   },
   computed: {
     productsAvailable() {
-      return this.products.retain.enabled || this.products.insights.enabled || this.products.verify.enabled;
+      return true // LAKI this.products.retain.enabled || this.products.insights.enabled || this.products.verify.enabled;
     }
   },
   methods: {
     confirm () {
+      this.$store.commit('resetNavHistory');
+      this.$store.commit('setNavHistory', '/4');
       this.$store.state.products = this.products;
       if (this.products.insights.selected && this.products.verify.selected) {
         this.$router.push('/5'); 
         this.$store.commit('setShouldConfigVerify', true);
       } else if (this.products.insights.selected) {
+        this.$store.commit('setShouldConfigVerify', false);
         this.$router.push('/5');
       } else if (this.products.verify.selected) {
         this.$router.push('/7');

--- a/lib/ui/public/app/config/Page5.vue
+++ b/lib/ui/public/app/config/Page5.vue
@@ -34,6 +34,7 @@
     <Navigation
       :onConfirm="confirm"
       :disableConfirm="selected === 'none'"
+      :navHistory="navHistory"
     />
   </div>
 </template>
@@ -46,7 +47,8 @@ export default {
     return {
       fields: this.$store.state.v4Fields,
       header: false,
-      selected: 'none'
+      selected: 'none',
+      navHistory: this.$store.getters.getNavHistory
     };
   },
   components: {
@@ -74,6 +76,7 @@ export default {
       this.header = this.selected === 'all';
     },
     confirm () {
+      this.$store.commit('setNavHistory', '/5');
       const shouldConfigVerify = this.$store.getters.getShouldConfigVerify;
       this.$store.state.v4Fields = this.fields;
       if (this.fields.page_scan?.selected) {

--- a/lib/ui/public/app/config/Page5.vue
+++ b/lib/ui/public/app/config/Page5.vue
@@ -74,10 +74,14 @@ export default {
       this.header = this.selected === 'all';
     },
     confirm () {
+      const shouldConfigVerify = this.$store.dispatch('getShouldConfigVerify');
       this.$store.state.v4Fields = this.fields;
       if (this.fields.page_scan?.selected) {
-        this.$router.push('/6')
-        return
+        this.$router.push('/6');
+        return;
+      } else if (shouldConfigVerify) {
+        this.$router.push('/7');
+        return;
       }
       this.$store.dispatch('confirm');
     }

--- a/lib/ui/public/app/config/Page5.vue
+++ b/lib/ui/public/app/config/Page5.vue
@@ -74,7 +74,7 @@ export default {
       this.header = this.selected === 'all';
     },
     confirm () {
-      const shouldConfigVerify = this.$store.dispatch('getShouldConfigVerify');
+      const shouldConfigVerify = this.$store.getters.getShouldConfigVerify;
       this.$store.state.v4Fields = this.fields;
       if (this.fields.page_scan?.selected) {
         this.$router.push('/6');

--- a/lib/ui/public/app/config/Page6.vue
+++ b/lib/ui/public/app/config/Page6.vue
@@ -76,7 +76,7 @@ export default {
         forbidden: this.forbiddenTags
       });
 
-      const shouldConfigVerify = this.$store.dispatch('getShouldConfigVerify');
+      const shouldConfigVerify = this.$store.getters.getShouldConfigVerify;
       if (shouldConfigVerify) {
         this.$router.push('/7');
       } else {

--- a/lib/ui/public/app/config/Page6.vue
+++ b/lib/ui/public/app/config/Page6.vue
@@ -59,7 +59,7 @@ export default {
       forbiddenTags: [],
       /** @type {string[]} */
       forbiddenOptions: [],
-    }
+    };
   },
   methods: {
     handleRequiredTag(tag) {
@@ -75,10 +75,16 @@ export default {
         required: this.requiredTags,
         forbidden: this.forbiddenTags
       });
-      this.$store.dispatch('confirm'); 
+
+      const shouldConfigVerify = this.$store.dispatch('getShouldConfigVerify');
+      if (shouldConfigVerify) {
+        this.$router.push('/7');
+      } else {
+        this.$store.dispatch('confirm'); 
+      }
     },
   }
-}
+};
 </script>
 
 <style scoped>

--- a/lib/ui/public/app/config/Page6.vue
+++ b/lib/ui/public/app/config/Page6.vue
@@ -35,6 +35,7 @@
     <Navigation
       :onConfirm="confirm"
       :disableConfirm="false"
+      :navHistory="navHistory"
     />
   </div>
 </template>
@@ -59,6 +60,8 @@ export default {
       forbiddenTags: [],
       /** @type {string[]} */
       forbiddenOptions: [],
+      /** @type {string[]} */
+      navHistory: this.$store.getters.getNavHistory
     };
   },
   methods: {
@@ -71,13 +74,12 @@ export default {
       this.forbiddenOptions.push(tag);
     },
     confirm() {
+      this.$store.commit('setNavHistory', '/6')
       this.$store.commit('setPageScan', {
         required: this.requiredTags,
         forbidden: this.forbiddenTags
       });
-
-      const shouldConfigVerify = this.$store.getters.getShouldConfigVerify;
-      if (shouldConfigVerify) {
+      if (this.$store.getters.getShouldConfigVerify) {
         this.$router.push('/7');
       } else {
         this.$store.dispatch('confirm'); 

--- a/lib/ui/public/app/config/Page7.vue
+++ b/lib/ui/public/app/config/Page7.vue
@@ -1,0 +1,62 @@
+<template>
+    <div>
+      <header>
+        Configure TrustedForm Verify
+      </header>
+      <section>
+        <p>
+          Enter the name of the legal entity for an advertiser that will be used to determine if they
+          were given consent in a one to one manner.
+        </p>
+        <Form :actions="false">
+          <TextField
+            v-model="advertiserName"
+          ></TextField>
+        </Form>
+      </section>
+      <Navigation
+        :onConfirm="confirm"
+        :disableConfirm="false"
+      />
+    </div>
+  </template>
+  
+  <script>
+  import { Navigation } from '@activeprospect/integration-components';
+  import { TextField, Form } from '@activeprospect/ui-components';
+  
+  export default {
+    components: {
+      Navigation,
+      TextField,
+      Form
+    },
+    data() {
+      return {
+        /** @type {string} */
+        advertiserName: "",
+      };
+    },
+    methods: {
+      confirm() {
+        this.$store.commit('setAdvertiserName', {
+          advertiserName: this.advertiserName
+        });
+        this.$store.dispatch('confirm'); 
+      },
+    }
+  };
+  </script>
+
+<style scoped>
+/* All the selectors here use `:deep()` because otherwise the styles can't be scoped, since the classes are added by a library. */
+
+/** override this style https://github.com/activeprospect/leadconduit-client/blob/a005d3ac5627aa39d12c64756561ef400b512bf3/public/css/core/forms.styl#L252-L254 */
+
+:deep(.formkit-inner) {
+  width: 100%;
+  display: block;
+  padding: 0;
+}
+
+</style>

--- a/lib/ui/public/app/config/Page7.vue
+++ b/lib/ui/public/app/config/Page7.vue
@@ -54,9 +54,6 @@
   </script>
 
 <style scoped>
-/* All the selectors here use `:deep()` because otherwise the styles can't be scoped, since the classes are added by a library. */
-
-/** override this style https://github.com/activeprospect/leadconduit-client/blob/a005d3ac5627aa39d12c64756561ef400b512bf3/public/css/core/forms.styl#L252-L254 */
 
 input {
   width: 65%;

--- a/lib/ui/public/app/config/Page7.vue
+++ b/lib/ui/public/app/config/Page7.vue
@@ -9,14 +9,17 @@
           were given consent in a one to one manner.
         </p>
         <Form :actions="false">
-          <TextField
+          <input
             v-model="advertiserName"
-          ></TextField>
+            type="text"
+            placeholder="(optional) keep empty if you don't need to check one-to-one consent"
+          ></input>
         </Form>
       </section>
       <Navigation
         :onConfirm="confirm"
         :disableConfirm="false"
+        :navHistory="navHistory"
       />
     </div>
   </template>
@@ -35,6 +38,8 @@
       return {
         /** @type {string} */
         advertiserName: "",
+        /** @type {string[]} */
+        navHistory: this.$store.getters.getNavHistory
       };
     },
     methods: {
@@ -53,10 +58,8 @@
 
 /** override this style https://github.com/activeprospect/leadconduit-client/blob/a005d3ac5627aa39d12c64756561ef400b512bf3/public/css/core/forms.styl#L252-L254 */
 
-:deep(.formkit-inner) {
-  width: 100%;
-  display: block;
-  padding: 0;
+input {
+  width: 65%;
 }
 
 </style>

--- a/lib/ui/public/app/router.js
+++ b/lib/ui/public/app/router.js
@@ -6,6 +6,7 @@ import PageThree from './config/Page3.vue';
 import PageFour from './config/Page4.vue';
 import PageFive from './config/Page5.vue';
 import PageSix from './config/Page6.vue';
+import PageSeven from './config/Page7.vue';
 
 export default createRouter({
   history: createMemoryHistory(),
@@ -45,6 +46,11 @@ export default createRouter({
           path: '6',
           name: 'PageSix',
           component: PageSix
+        },
+        {
+          path: '7',
+          name: 'PageSeven',
+          component: PageSeven
         }
       ]
     }

--- a/lib/ui/public/app/store.js
+++ b/lib/ui/public/app/store.js
@@ -2,7 +2,7 @@ import { createStore } from 'vuex';
 import fieldData from './fieldData';
 import v4Fields from './v4fields';
 import axios from 'axios';
-import { castArray, get, set } from 'lodash';
+import { castArray, get, includes, set, uniq } from 'lodash';
 import { toRaw } from 'vue';
 
 const initStore = (config, ui) => createStore({
@@ -16,15 +16,16 @@ const initStore = (config, ui) => createStore({
     config,
     errors: undefined,
     products: {
-      retain: { enabled: false, selected: false },
-      insights: { enabled: false, selected: false },
-      verify: { enabled: false, selected: false }
+      retain: { enabled: true, selected: false }, // LAKI
+      insights: { enabled: true, selected: false },
+      verify: { enabled: true, selected: false }
     },
     filters: [],
     pageScanForbidden: [],
     pageScanRequired: [],
     advertiserName: undefined,
-    shouldConfigVerify: false
+    shouldConfigVerify: false,
+    navHistory: []
   },
   mutations: {
     setErrors (state, errors) {
@@ -46,6 +47,14 @@ const initStore = (config, ui) => createStore({
     setShouldConfigVerify(state, shouldConfigVerify) {
       state.shouldConfigVerify = shouldConfigVerify;
     },
+    setNavHistory(state, navHistory) {
+      if (!includes(state.navHistory, navHistory)) {
+        state.navHistory.push(navHistory);
+      }
+    },
+    resetNavHistory(state) {
+      state.navHistory = [];
+    }
   },
   getters: {
     getProducts: (state) => {
@@ -56,6 +65,9 @@ const initStore = (config, ui) => createStore({
     },
     getShouldConfigVerify: (state) => {
       return state.shouldConfigVerify;
+    },
+    getNavHistory: (state) => {
+      return state.navHistory
     }
   },
   actions: {

--- a/lib/ui/public/app/store.js
+++ b/lib/ui/public/app/store.js
@@ -16,9 +16,9 @@ const initStore = (config, ui) => createStore({
     config,
     errors: undefined,
     products: {
-      retain: { enabled: true, selected: false }, // LAKI
-      insights: { enabled: true, selected: false },
-      verify: { enabled: true, selected: false }
+      retain: { enabled: false, selected: false },
+      insights: { enabled: false, selected: false },
+      verify: { enabled: false, selected: false }
     },
     filters: [],
     pageScanForbidden: [],
@@ -197,9 +197,9 @@ const initStore = (config, ui) => createStore({
             reason: '{{trustedform.reason}}',
             outcome: 'failure',
             description: 'Filter leads that fail on Trustedform Verify check',
-
+            rules
           };
-          set(filterConfig, 'rules', rules);
+
           await context.dispatch('createFilter', filterConfig);
         }
         context.state.filters.forEach(filter => {

--- a/lib/ui/public/app/store.js
+++ b/lib/ui/public/app/store.js
@@ -16,14 +16,15 @@ const initStore = (config, ui) => createStore({
     config,
     errors: undefined,
     products: {
-      retain: { enabled: false, selected: false },
-      insights: { enabled: false, selected: false },
-      verify: { enabled: false, selected: false }
+      retain: { enabled: true, selected: false },
+      insights: { enabled: true, selected: false },
+      verify: { enabled: true, selected: false }
     },
     filters: [],
     pageScanForbidden: [],
     pageScanRequired: [],
-    advertiserName: undefined
+    advertiserName: undefined,
+    shouldConfigVerify: false
   },
   mutations: {
     setErrors (state, errors) {
@@ -99,6 +100,7 @@ const initStore = (config, ui) => createStore({
           }]
         };
       }
+
       const filter = {
         type: 'filter',
         reason: filterConfig.reason,
@@ -113,7 +115,7 @@ const initStore = (config, ui) => createStore({
       context.commit('setFilters', [...context.state.filters, filter]);
     },
     async confirm (context) {
-      const { products, v4Fields, pageScanForbidden, pageScanRequired } = context.state;
+      const { products, v4Fields, pageScanForbidden, pageScanRequired, advertiserName } = context.state;
       const flow = {
         steps: [{
           type: 'recipient',
@@ -160,6 +162,14 @@ const initStore = (config, ui) => createStore({
         }
 
         if (products.verify.selected) {
+
+          if(advertiserName) {
+            flow.steps[0].integration.mappings.push({
+              property: 'verify.advertiser_name',
+              value: advertiserName
+            });
+          }
+
           const verifyRules = {
             rulesOp: 'is not equal to',
             lhv: 'trustedform.outcome',
@@ -174,7 +184,7 @@ const initStore = (config, ui) => createStore({
             }
           ];
 
-          const rules = this.advertiserName ? oneToOneRules : verifyRules;
+          const rules = advertiserName ? oneToOneRules : [verifyRules];
 
           const filterConfig = {
             reason: '{{trustedform.reason}}',
@@ -192,6 +202,12 @@ const initStore = (config, ui) => createStore({
         });
       }
       context.state.ui.create({ flow });
+    },
+    setShouldConfigVerify(context, shouldConfigVerify) {
+      context.state.shouldConfigVerify = shouldConfigVerify;
+    },
+    getShouldConfigVerify(context) {
+      return context.state.shouldConfigVerify;
     }
   }
 });

--- a/lib/ui/public/app/store.js
+++ b/lib/ui/public/app/store.js
@@ -16,9 +16,9 @@ const initStore = (config, ui) => createStore({
     config,
     errors: undefined,
     products: {
-      retain: { enabled: true, selected: false },
-      insights: { enabled: true, selected: false },
-      verify: { enabled: true, selected: false }
+      retain: { enabled: false, selected: false },
+      insights: { enabled: false, selected: false },
+      verify: { enabled: false, selected: false }
     },
     filters: [],
     pageScanForbidden: [],

--- a/lib/ui/public/app/store.js
+++ b/lib/ui/public/app/store.js
@@ -2,7 +2,7 @@ import { createStore } from 'vuex';
 import fieldData from './fieldData';
 import v4Fields from './v4fields';
 import axios from 'axios';
-import { assign, castArray, get, isArray, set } from 'lodash';
+import { castArray, get, set } from 'lodash';
 import { toRaw } from 'vue';
 
 const initStore = (config, ui) => createStore({
@@ -42,7 +42,10 @@ const initStore = (config, ui) => createStore({
     },
     setAdvertiserName(state, {advertiserName}) {
       state.advertiserName = advertiserName;
-    }
+    },
+    setShouldConfigVerify(state, shouldConfigVerify) {
+      state.shouldConfigVerify = shouldConfigVerify;
+    },
   },
   getters: {
     getProducts: (state) => {
@@ -50,6 +53,9 @@ const initStore = (config, ui) => createStore({
     },
     getErrors: (state) => {
       return state.errors;
+    },
+    getShouldConfigVerify: (state) => {
+      return state.shouldConfigVerify;
     }
   },
   actions: {
@@ -82,24 +88,13 @@ const initStore = (config, ui) => createStore({
         });
     },
     createFilter(context, filterConfig) {
-      let rules;
-      if (isArray(filterConfig.rules)) {
-        rules = filterConfig.rules.map(rule => {
+      const rules = filterConfig.rules.map(rule => {
           return {
             op: rule.rulesOp,
             lhv: rule.lhv,
             rhv: rule.rhv
           };
         });
-      } else { 
-        rules = {
-          rules: [{
-            op: filterConfig.rulesOp,
-            lhv: filterConfig.lhv,
-            rhv: filterConfig.rhv
-          }]
-        };
-      }
 
       const filter = {
         type: 'filter',
@@ -165,7 +160,7 @@ const initStore = (config, ui) => createStore({
 
           if(advertiserName) {
             flow.steps[0].integration.mappings.push({
-              property: 'verify.advertiser_name',
+              property: 'trustedform.advertiser_name',
               value: advertiserName
             });
           }
@@ -180,7 +175,7 @@ const initStore = (config, ui) => createStore({
             { ...verifyRules },
             {
               rulesOp: 'is false',
-              lhv: 'trustedform.verify.one_to_one',
+              lhv: 'trustedform.one_to_one',
             }
           ];
 
@@ -192,7 +187,7 @@ const initStore = (config, ui) => createStore({
             description: 'Filter leads that fail on Trustedform Verify check',
 
           };
-          isArray(rules) ? set(filterConfig, 'rules', rules) : assign(filterConfig, rules);
+          set(filterConfig, 'rules', rules);
           await context.dispatch('createFilter', filterConfig);
         }
         context.state.filters.forEach(filter => {
@@ -203,12 +198,6 @@ const initStore = (config, ui) => createStore({
       }
       context.state.ui.create({ flow });
     },
-    setShouldConfigVerify(context, shouldConfigVerify) {
-      context.state.shouldConfigVerify = shouldConfigVerify;
-    },
-    getShouldConfigVerify(context) {
-      return context.state.shouldConfigVerify;
-    }
   }
 });
 

--- a/lib/ui/public/app/store.js
+++ b/lib/ui/public/app/store.js
@@ -2,7 +2,7 @@ import { createStore } from 'vuex';
 import fieldData from './fieldData';
 import v4Fields from './v4fields';
 import axios from 'axios';
-import { castArray, get } from 'lodash';
+import { assign, castArray, get, isArray, set } from 'lodash';
 import { toRaw } from 'vue';
 
 const initStore = (config, ui) => createStore({
@@ -23,6 +23,7 @@ const initStore = (config, ui) => createStore({
     filters: [],
     pageScanForbidden: [],
     pageScanRequired: [],
+    advertiserName: undefined
   },
   mutations: {
     setErrors (state, errors) {
@@ -37,6 +38,9 @@ const initStore = (config, ui) => createStore({
     setPageScan(state, { required, forbidden }) {
       state.pageScanRequired = required;
       state.pageScanForbidden = forbidden;
+    },
+    setAdvertiserName(state, {advertiserName}) {
+      state.advertiserName = advertiserName;
     }
   },
   getters: {
@@ -77,17 +81,31 @@ const initStore = (config, ui) => createStore({
         });
     },
     createFilter(context, filterConfig) {
+      let rules;
+      if (isArray(filterConfig.rules)) {
+        rules = filterConfig.rules.map(rule => {
+          return {
+            op: rule.rulesOp,
+            lhv: rule.lhv,
+            rhv: rule.rhv
+          };
+        });
+      } else { 
+        rules = {
+          rules: [{
+            op: filterConfig.rulesOp,
+            lhv: filterConfig.lhv,
+            rhv: filterConfig.rhv
+          }]
+        };
+      }
       const filter = {
         type: 'filter',
         reason: filterConfig.reason,
         outcome: filterConfig.outcome,
         rule_set: {
           op: 'and',
-          rules: [{
-            op: filterConfig.rulesOp,
-            lhv: filterConfig.lhv,
-            rhv: filterConfig.rhv
-          }]
+          rules
         },
         description: filterConfig.description,
         enabled: true
@@ -142,14 +160,29 @@ const initStore = (config, ui) => createStore({
         }
 
         if (products.verify.selected) {
-          const filterConfig = {
-            reason: '{{trustedform.reason}}',
+          const verifyRules = {
             rulesOp: 'is not equal to',
             lhv: 'trustedform.outcome',
             rhv: 'success',
-            outcome: 'failure',
-            description: 'Filter leads that fail on Trustedform Verify check'
           };
+
+          const oneToOneRules = [
+            { ...verifyRules },
+            {
+              rulesOp: 'is false',
+              lhv: 'trustedform.verify.one_to_one',
+            }
+          ];
+
+          const rules = this.advertiserName ? oneToOneRules : verifyRules;
+
+          const filterConfig = {
+            reason: '{{trustedform.reason}}',
+            outcome: 'failure',
+            description: 'Filter leads that fail on Trustedform Verify check',
+
+          };
+          isArray(rules) ? set(filterConfig, 'rules', rules) : assign(filterConfig, rules);
           await context.dispatch('createFilter', filterConfig);
         }
         context.state.filters.forEach(filter => {

--- a/test/trustedform_spec.js
+++ b/test/trustedform_spec.js
@@ -137,7 +137,9 @@ describe('v4', () => {
               'seconds_on_page'
             ]
           },
-          verify: {}
+          verify: {
+            advertiser_name: 'test'
+          }
         }),
         headers: {
           'Content-Type': 'application/json',
@@ -162,7 +164,8 @@ describe('v4', () => {
           page_url: 'true',
           parent_page_url: 'true',
           time_on_page: 'true'
-        }
+        },
+        trustedform: { advertiser_name: 'test' }
       });
       assert.deepEqual(integration.request(vars), expected);
     });
@@ -333,6 +336,22 @@ describe('v4', () => {
       });
       assert.deepEqual(integration.request(vars).body, expected);
     });
+    it('should correctly format a verify only request with 1:1 consent check', () => {
+      const expected = JSON.stringify({
+        verify: {
+          advertiser_name: 'test'
+        }
+      });
+      const vars = baseVars({
+        trustedform: {
+          retain: 'false',
+          insights: 'false',
+          advertiser_name: 'test'
+        },
+        verify: {}
+      });
+      assert.deepEqual(integration.request(vars).body, expected);
+    });
   });
 
   it('should use a custom api key when present', () => {
@@ -491,11 +510,11 @@ describe('v4', () => {
         time_on_page_in_seconds: 8374,
         time_zone: 'America/Chicago',
         vendor: 'Inbound Verbose',
+        one_to_one: true,
         verify: {
           languages: ['I understand that the TrustedForm certificate is sent to the email address I provided above and I will receive product updates as they are released.'],
           language_approved: true,
-          success: true,
-          one_to_one: true
+          success: true
         }
       };
       assert.deepEqual(integration.response({ insights: { page_scan: true }}, {}, res), expected);

--- a/test/trustedform_spec.js
+++ b/test/trustedform_spec.js
@@ -443,7 +443,8 @@ describe('v4', () => {
             ],
             result: {
               language_approved: true,
-              success: true
+              success: true,
+              one_to_one: true
             }
           }
         })
@@ -493,7 +494,8 @@ describe('v4', () => {
         verify: {
           languages: ['I understand that the TrustedForm certificate is sent to the email address I provided above and I will receive product updates as they are released.'],
           language_approved: true,
-          success: true
+          success: true,
+          one_to_one: true
         }
       };
       assert.deepEqual(integration.response({ insights: { page_scan: true }}, {}, res), expected);


### PR DESCRIPTION
## Description of the change

Adding 1:1 Consent Check Advertiser Name configuration and One To One Filter

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change
- [ ] Technical Debt
- [ ] Documentation

## Related tickets

[Ticket](https://app.shortcut.com/active-prospect/story/77184/trustedform-v4-verify-add-1-1-consent-check-feature)

## Checklists

### Development and Testing

- [X]  Lint rules pass locally.
- [X]  The code changed/added as part of this pull request has been covered with tests, or this PR does not alter production code.
- [X]  All tests related to the changed code pass in development, or tests are not applicable.

### Code Review

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.
- [ ]  At least two engineers have been added as "Reviewers" on the pull request.
- [ ]  Changes have been reviewed by at least two other engineers who did not write the code.
- [ ]  This branch has been rebased off master to be current.

### Tracking 
- [ ]  Issue from Shortcut/Jira has a link to this pull request.
- [ ]  This PR has a link to the issue in Shortcut.

### QA
- [ ]  This branch has been deployed to staging and tested.
