### PR TITLE
Retrieving the current products configs when re-opening the Rich UI

### DIFF
--- a/lib/ui/public/app/store.js
+++ b/lib/ui/public/app/store.js
@@ -42,6 +42,13 @@ const initializePageScanFields = (mappings, field) => {
   }
 };
 
+const initializeProductSelection = (mappings, product) => {
+  if (Array.isArray(mappings)) {
+    const mapping = mappings.find(item => item.property === `trustedform.${product}`);
+    return mapping ? mapping.value === 'true' : false;
+  }
+};
+
 const initStore = (config, ui) => createStore({
   state: {
     // field descriptions
@@ -116,14 +123,12 @@ const initStore = (config, ui) => createStore({
       context.state.ui.cancel();
     },
     getProducts (context) {
-      // Bypassing the API call for local testing
       const availableProducts = [
         'retain',
         'insights',
         'verify'
       ];
     
-      // Original API call - temporarily disabled for local testing
       return axios
         .get(`account?apiKey=${config.credential.token}`)
         .then(function (response) {
@@ -131,7 +136,7 @@ const initStore = (config, ui) => createStore({
           availableProducts.forEach(function (product) {
             context.commit('setProduct', { product, value: {
               enabled: products.includes(product),
-              selected: false
+              selected: products.includes(product) && initializeProductSelection(config.mappings, product)
             }});
           });
         })


### PR DESCRIPTION
## Description of the change

Fixing the issue with Trustedform rich UI reopening where the configured products aren't initializing as selected

## Type of change
- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change
- [ ] Technical Debt
- [ ] Documentation

## Related tickets

https://app.shortcut.com/active-prospect/story/86334/implement-edit-step-for-trustedform-add-on

## Checklists

### Development and Testing

- [X]  Lint rules pass locally.
- [ ]  The code changed/added as part of this pull request has been covered with tests, or this PR does not alter production code.
- [X]  All tests related to the changed code pass in development, or tests are not applicable.

### Code Review

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.
- [ ]  At least two engineers have been added as "Reviewers" on the pull request.
- [ ]  Changes have been reviewed by at least two other engineers who did not write the code.
- [ ]  This branch has been rebased off master to be current.

### Tracking 
- [ ]  Issue from Shortcut/Jira has a link to this pull request.
- [ ]  This PR has a link to the issue in Shortcut.

### QA
- [ ]  This branch has been deployed to staging and tested.
