### PR TITLE
Sc 88181/trustedform v4 verify include min font size

### DIFF
--- a/lib/trustedform.js
+++ b/lib/trustedform.js
@@ -276,13 +276,14 @@ response.variables = () => [
   { name: 'os_name', type: 'string', description: 'Operating system name' },
   { name: 'page_url', type: 'string', description: 'The URL of the page hosting TrustedForm Certify.' },
   { name: 'parent_page_url', type: 'string', description: 'The parent URL of the page hosting TrustedForm Certify, if framed.' },
+  { name: 'bot_detected', type: 'boolean', description: 'A boolean indicating if a bot was detected on the page.' },
   { name: 'one_to_one', type: 'boolean', description: 'A boolean indicating if the cert structure satisfied the requirements for 1:1 consent.' },
   { name: 'verify.languages', type: 'array', description: 'A list of the consent languages detected within the certificate' },
   { name: 'verify.language_approved', type: 'boolean', description: 'A boolean indicating if any of the consent languages found have been approved in your account\'s consent language manager.' },
   { name: 'verify.form_submitted', type: 'boolean', description: 'A boolean indicating whether the form was successfully submitted by the consumer.' },
   { name: 'verify.success', type: 'boolean', description: 'A boolean indicating if any of the consent languages found meet the success criteria defined for your account.' },
-  { name: 'verify.font_size', type: 'boolean', description: 'A boolean indicating whether the consent language meets or exceeds the required minimum font size. true means the font size requirement was satisfied, while false indicates it was not. A null value is returned when the min_font_size_px_required is missing, and the check could not be performed.' },
-  { name: 'verify.contrast_ratio', type: 'boolean', description: 'A boolean indicating whether the contrast ratio between the consent language text and background meets or exceeds the required minimum contrast ratio. true means the contrast requirement was satisfied, while false means it was insufficient. A null value is returned when the min_contrast_ratio_required is missing, and the check could not be performed.' },
+  { name: 'verify.font_size', type: 'boolean', description: 'True when the consent language font size meets or exceeds the value configured in TrustedForm.' },
+  { name: 'verify.contrast_ratio', type: 'boolean', description: 'True when the contrast ratio between the consent language text and background meets or exceeds the value configured in TrustedForm.' }
 ];
 
 const editable = true;

--- a/lib/trustedform.js
+++ b/lib/trustedform.js
@@ -65,7 +65,8 @@ const formatProperties = (insights) => {
     { mapping: 'operating_system', value: 'os' },
     { mapping: 'page_url', value: 'page_url' },
     { mapping: 'parent_page_url', value: 'parent_page_url' },
-    { mapping: 'time_on_page', value: 'seconds_on_page' }
+    { mapping: 'time_on_page', value: 'seconds_on_page' },
+    { mapping: 'bot_detected', value: 'bot_detected' }
   ];
 
   let selectedProps = insightsProps.map((field) => {
@@ -105,6 +106,7 @@ request.variables = () => [
   { name: 'insights.time_on_page', type: 'boolean', required: false, description: 'Request TrustedForm Insights time on page data?' },
   { name: 'insights.page_url', type: 'boolean', required: false, description: 'Request TrustedForm Insights page URL data?' },
   { name: 'insights.page_scan', type: 'boolean', required: false, description: 'Request TrustedForm Insights page scan data?' },
+  { name: 'insights.bot_detected', type: 'boolean', required: false, description: 'Request TrustedForm Insights bot detection data?' },
   { name: 'trustedform.scan_required_text', type: 'array', required: false, description: 'A list of required text to scan for. TrustedForm will then perform a case and whitespace insensitive search for the string.' },
   { name: 'trustedform.scan_forbidden_text', type: 'array', required: false, description: 'A list of forbidden text to scan for. TrustedForm will then perform a case and whitespace insensitive search for the string.' },
   { name: 'trustedform.scan_delimiter', type: 'string', required: false, description: 'Use this parameter to designate a delimiter when wrapping wildcards or template variables; defaults to |.' },
@@ -128,7 +130,8 @@ const verifyEnabled = (vars) => vars.trustedform?.verify?.valueOf();
 const hasRequiredRetainProps = (vars) => !!(vars.lead.email || vars.lead.phone_1);
 const hasAtLeastOneInsightsProp = (vars) => formatProperties(vars.insights).length > 0 || vars.insights?.page_scan?.valueOf();
 const hasVerifyData = (data) => {
-  return data.verify?.languages || data.verify?.result?.language_approved || data.verify?.result?.success || data.verify?.result?.one_to_one;
+  return data.verify?.languages 
+  || data.verify?.result;
 };
 
 const response = (vars, req, res) => {
@@ -139,10 +142,12 @@ const response = (vars, req, res) => {
         const verify = hasVerifyData(parsed)
           ? pickBy({
               languages: parsed.verify.languages.map(lang => lang.text),
-              form_submitted: parsed.verify.result.form_submitted,
-              language_approved: parsed.verify.result.language_approved,
+              form_submitted: parsed.verify.result?.form_submitted,
+              language_approved: parsed.verify.result?.language_approved,
               // note that the Verify one_to_one value is handled separately
-              success: parsed.verify.result.success,
+              success: parsed.verify.result?.success,
+              min_font_size_px_satisfied: parsed.verify.result?.min_font_size_px_satisfied,
+              min_contrast_ratio_satisfied: parsed.verify.result?.min_contrast_ratio_satisfied,
             }, (v) => !isUndefined(v))
           : undefined;
 
@@ -194,6 +199,7 @@ const response = (vars, req, res) => {
           os_name: parsed.insights?.properties?.os?.name,
           page_url: parsed.insights?.properties?.page_url,
           parent_page_url: parsed.insights?.properties?.parent_page_url,
+          bot_detected: parsed.insights?.properties?.bot_detected,
           one_to_one: parsed.verify?.result?.one_to_one,
           verify
         }, (v) => { return !isUndefined(v); });
@@ -275,6 +281,8 @@ response.variables = () => [
   { name: 'verify.language_approved', type: 'boolean', description: 'A boolean indicating if any of the consent languages found have been approved in your account\'s consent language manager.' },
   { name: 'verify.form_submitted', type: 'boolean', description: 'A boolean indicating whether the form was successfully submitted by the consumer.' },
   { name: 'verify.success', type: 'boolean', description: 'A boolean indicating if any of the consent languages found meet the success criteria defined for your account.' },
+  { name: 'verify.min_font_size_px_satisfied', type: 'boolean', description: 'A boolean indicating whether the consent language meets or exceeds the required minimum font size. true means the font size requirement was satisfied, while false indicates it was not. A null value is returned when the min_font_size_px_required is missing, and the check could not be performed.' },
+  { name: 'verify.min_contrast_ratio_satisfied', type: 'boolean', description: 'A boolean indicating whether the contrast ratio between the consent language text and background meets or exceeds the required minimum contrast ratio. true means the contrast requirement was satisfied, while false means it was insufficient. A null value is returned when the min_contrast_ratio_required is missing, and the check could not be performed.' },
 ];
 
 const editable = true;

--- a/lib/trustedform.js
+++ b/lib/trustedform.js
@@ -146,8 +146,8 @@ const response = (vars, req, res) => {
               language_approved: parsed.verify.result?.language_approved,
               // note that the Verify one_to_one value is handled separately
               success: parsed.verify.result?.success,
-              min_font_size_px_satisfied: parsed.verify.result?.min_font_size_px_satisfied,
-              min_contrast_ratio_satisfied: parsed.verify.result?.min_contrast_ratio_satisfied,
+              font_size: parsed.verify.result?.min_font_size_px_satisfied,
+              contrast_ratio: parsed.verify.result?.min_contrast_ratio_satisfied,
             }, (v) => !isUndefined(v))
           : undefined;
 
@@ -281,8 +281,8 @@ response.variables = () => [
   { name: 'verify.language_approved', type: 'boolean', description: 'A boolean indicating if any of the consent languages found have been approved in your account\'s consent language manager.' },
   { name: 'verify.form_submitted', type: 'boolean', description: 'A boolean indicating whether the form was successfully submitted by the consumer.' },
   { name: 'verify.success', type: 'boolean', description: 'A boolean indicating if any of the consent languages found meet the success criteria defined for your account.' },
-  { name: 'verify.min_font_size_px_satisfied', type: 'boolean', description: 'A boolean indicating whether the consent language meets or exceeds the required minimum font size. true means the font size requirement was satisfied, while false indicates it was not. A null value is returned when the min_font_size_px_required is missing, and the check could not be performed.' },
-  { name: 'verify.min_contrast_ratio_satisfied', type: 'boolean', description: 'A boolean indicating whether the contrast ratio between the consent language text and background meets or exceeds the required minimum contrast ratio. true means the contrast requirement was satisfied, while false means it was insufficient. A null value is returned when the min_contrast_ratio_required is missing, and the check could not be performed.' },
+  { name: 'verify.font_size', type: 'boolean', description: 'A boolean indicating whether the consent language meets or exceeds the required minimum font size. true means the font size requirement was satisfied, while false indicates it was not. A null value is returned when the min_font_size_px_required is missing, and the check could not be performed.' },
+  { name: 'verify.contrast_ratio', type: 'boolean', description: 'A boolean indicating whether the contrast ratio between the consent language text and background meets or exceeds the required minimum contrast ratio. true means the contrast requirement was satisfied, while false means it was insufficient. A null value is returned when the min_contrast_ratio_required is missing, and the check could not be performed.' },
 ];
 
 const editable = true;

--- a/lib/trustedform.js
+++ b/lib/trustedform.js
@@ -276,7 +276,7 @@ response.variables = () => [
   { name: 'os_name', type: 'string', description: 'Operating system name' },
   { name: 'page_url', type: 'string', description: 'The URL of the page hosting TrustedForm Certify.' },
   { name: 'parent_page_url', type: 'string', description: 'The parent URL of the page hosting TrustedForm Certify, if framed.' },
-  { name: 'bot_detected', type: 'boolean', description: 'A boolean indicating if a bot was detected on the page.' },
+  { name: 'bot_detected', type: 'boolean', description: 'A boolean indicating whether the events documented were likely produced by a non-human entity based on ActiveProspect\'s proprietary algorithms.' },
   { name: 'one_to_one', type: 'boolean', description: 'A boolean indicating if the cert structure satisfied the requirements for 1:1 consent.' },
   { name: 'verify.languages', type: 'array', description: 'A list of the consent languages detected within the certificate' },
   { name: 'verify.language_approved', type: 'boolean', description: 'A boolean indicating if any of the consent languages found have been approved in your account\'s consent language manager.' },

--- a/lib/trustedform.js
+++ b/lib/trustedform.js
@@ -144,10 +144,10 @@ const response = (vars, req, res) => {
               languages: parsed.verify.languages.map(lang => lang.text),
               form_submitted: parsed.verify.result?.form_submitted,
               language_approved: parsed.verify.result?.language_approved,
-              // note that the Verify one_to_one value is handled separately
-              success: parsed.verify.result?.success,
               font_size: parsed.verify.result?.min_font_size_px_satisfied,
               contrast_ratio: parsed.verify.result?.min_contrast_ratio_satisfied,
+              // note that the Verify one_to_one value is handled separately
+              success: parsed.verify.result?.success,
             }, (v) => !isUndefined(v))
           : undefined;
 

--- a/lib/ui/public/app/v4fields.js
+++ b/lib/ui/public/app/v4fields.js
@@ -29,6 +29,11 @@ module.exports = {
     description: 'Whether or not the lead event took place inside of an iframe. <a href="https://www.techtarget.com/whatis/definition/IFrame-Inline-Frame" target="_blank">Learn More.</a>',
     enabled: false
   },
+  bot_detected: {
+    name: 'Bot Detection',
+    description: 'A determination of whether the events documented were likely produced by a non-human entity based on ActiveProspect’s proprietary algorithms. <a href="https://community.activeprospect.com/posts/5424099" target="_blank">Learn more.</a>',
+    enabled: false
+  },
   form_input_method: {
     name: 'Form Input Method',
     description: 'A list of ways the consumer input their data onto the form including one or more of the following: typing, paste, autofill.',
@@ -94,9 +99,4 @@ module.exports = {
     description: 'The amount of time, in seconds, that the consumer spent on the page during the lead event.',
     enabled: false
   },
-  bot_detected: {
-    name: 'Bot Detection',
-    description: 'A determination of whether the events documented were likely produced by a non-human entity based on ActiveProspect’s proprietary algorithms. <a href="https://community.activeprospect.com/posts/5424099" target="_blank">Learn more.</a>',
-    enabled: false
-  }
 };

--- a/lib/ui/public/app/v4fields.js
+++ b/lib/ui/public/app/v4fields.js
@@ -94,4 +94,9 @@ module.exports = {
     description: 'The amount of time, in seconds, that the consumer spent on the page during the lead event.',
     enabled: false
   },
+  bot_detected: {
+    name: 'Bot Detection',
+    description: 'A determination of whether the events documented were likely produced by a non-human entity based on ActiveProspect’s proprietary algorithms. <a href="https://community.activeprospect.com/posts/5424099" target="_blank">Learn more.</a>',
+    enabled: false
+  }
 };

--- a/test/trustedform_spec.js
+++ b/test/trustedform_spec.js
@@ -527,8 +527,8 @@ describe('v4', () => {
           language_approved: true,
           form_submitted: true,
           success: true,
-          min_font_size_px_satisfied: true,
-          min_contrast_ratio_satisfied: true
+          font_size: true,
+          contrast_ratio: true
         }
       };
       assert.deepEqual(integration.response({ insights: { page_scan: true }}, {}, res), expected);

--- a/test/trustedform_spec.js
+++ b/test/trustedform_spec.js
@@ -134,7 +134,8 @@ describe('v4', () => {
               'os',
               'page_url',
               'parent_page_url',
-              'seconds_on_page'
+              'seconds_on_page',
+              'bot_detected'
             ]
           },
           verify: {
@@ -163,7 +164,8 @@ describe('v4', () => {
           operating_system: 'true',
           page_url: 'true',
           parent_page_url: 'true',
-          time_on_page: 'true'
+          time_on_page: 'true',
+          bot_detected: 'true'
         },
         trustedform: { advertiser_name: 'test' }
       });
@@ -248,7 +250,8 @@ describe('v4', () => {
               'os',
               'page_url',
               'parent_page_url',
-              'seconds_on_page'
+              'seconds_on_page',
+              'bot_detected'
             ]
           }
         }),
@@ -274,7 +277,8 @@ describe('v4', () => {
           operating_system: 'true',
           page_url: 'true',
           parent_page_url: 'true',
-          time_on_page: 'true'
+          time_on_page: 'true',
+          bot_detected: 'true'
         }
       });
       delete vars.trustedform.verify;
@@ -413,7 +417,8 @@ describe('v4', () => {
               },
               page_url: 'https://activeprospect.github.io/certificate_staging.html',
               parent_page_url: null,
-              seconds_on_page: 8374
+              seconds_on_page: 8374,
+              bot_detected: false
             },
             scans: {
               forbidden: [],
@@ -465,7 +470,9 @@ describe('v4', () => {
               language_approved: true,
               success: true,
               form_submitted: true,
-              one_to_one: true
+              one_to_one: true,
+              min_font_size_px_satisfied: true,
+              min_contrast_ratio_satisfied: true
             }
           }
         })
@@ -513,12 +520,15 @@ describe('v4', () => {
         time_on_page_in_seconds: 8374,
         time_zone: 'America/Chicago',
         vendor: 'Inbound Verbose',
+        bot_detected: false,
         one_to_one: true,
         verify: {
           languages: ['I understand that the TrustedForm certificate is sent to the email address I provided above and I will receive product updates as they are released.'],
           language_approved: true,
           form_submitted: true,
-          success: true
+          success: true,
+          min_font_size_px_satisfied: true,
+          min_contrast_ratio_satisfied: true
         }
       };
       assert.deepEqual(integration.response({ insights: { page_scan: true }}, {}, res), expected);


### PR DESCRIPTION
## Description of the change

- Add Verify `min_font_size_px_satisfied` and `min_contrast_ratio_satisfied` to appended data
- Add Insights `bot_detected`

Although they’re two separate tickets, both should be delivered together.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change
- [ ] Technical Debt
- [ ] Documentation

## Related tickets

https://app.shortcut.com/active-prospect/story/88181/trustedform-v4-verify-include-min-font-size-px-satisfied-and-min-contrast-ratio-satisfied-as-an-appended-field

https://app.shortcut.com/active-prospect/story/88247/trustedform-v4-insights-include-bot-detected-property

## Checklists

### Development and Testing

- [X]  Lint rules pass locally.
- [X]  The code changed/added as part of this pull request has been covered with tests, or this PR does not alter production code.
- [X]  All tests related to the changed code pass in development, or tests are not applicable.

### Code Review

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.
- [ ]  At least two engineers have been added as "Reviewers" on the pull request.
- [ ]  Changes have been reviewed by at least two other engineers who did not write the code.
- [ ]  This branch has been rebased off master to be current.

### Tracking 
- [ ]  Issue from Shortcut/Jira has a link to this pull request.
- [ ]  This PR has a link to the issue in Shortcut.

### QA
- [ ]  This branch has been deployed to staging and tested.
