### PR TITLE
add support for cpl-token and update changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,31 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org)
 
-## [2.4.3] - 2025-01-08
+## [2.5.0] - 2025-04-08
+### Added
+- v4 now includes CPL token when present ([sc-87918](https://app.shortcut.com/active-prospect/story/87918/send-cpl-data-to-trustedform))
+
+## [2.4.8] - 2025-03-25
+### Added
+- v4 Insights now supports `bot_detected` field
+- v4 Verify now appends `min_font_size_px_satisfied` and `min_contrast_ratio_satisfied`
+
+## [2.4.7] - 2025-03-06
+### Added
+- RUI now supports being re-opened
+
+## [2.4.4] - 2025-01-08
 ### Fixed
 - v4 now appends `share_url` ([sc-84484](https://app.shortcut.com/active-prospect/story/84484/trustedform-v4-retain-include-trustedform-share-url-as-an-appended-field))
   and `verify.form_submitted` ([sc-84576](https://app.shortcut.com/active-prospect/story/84576/trustedform-v4-verify-include-form-submitted-as-an-appended-field))
+
+## [2.4.3] - 2024-09-26
+### Added
+- v4 now supports Advertiser Name mapping and appends `one_to_one`
+
+## [2.4.2] - 2024-09-17
+### Fixed
+- fixed an issue with appended Verify fields
 
 ## [2.4.1] - 2024-08-12
 ### Added

--- a/lib/trustedform.js
+++ b/lib/trustedform.js
@@ -34,15 +34,21 @@ const request = (vars) => {
     body.verify = pickBy({ advertiser_name: advertiserName }, (v) => { return !isUndefined(v); });
   }
 
+  const headers = {
+    'Content-Type': 'application/json',
+    'api-version': '4.0',
+    Authorization: `Basic ${Buffer.from(`X:${trustedform.api_key || vars.activeprospect.api_key}`).toString('base64')}`
+  };
+
+  if(process.env.TRUSTEDFORM_CPL_TOKEN) {
+    headers['CPL-Token'] = process.env.TRUSTEDFORM_CPL_TOKEN;
+  }
+
   return {
     method: 'POST',
     url: lead.trustedform_cert_url.toString(),
     body: JSON.stringify(body),
-    headers: {
-      'Content-Type': 'application/json',
-      'api-version': '4.0',
-      Authorization: `Basic ${Buffer.from(`X:${trustedform.api_key || vars.activeprospect.api_key}`).toString('base64')}`
-    }
+    headers
   };
 };
 
@@ -130,7 +136,7 @@ const verifyEnabled = (vars) => vars.trustedform?.verify?.valueOf();
 const hasRequiredRetainProps = (vars) => !!(vars.lead.email || vars.lead.phone_1);
 const hasAtLeastOneInsightsProp = (vars) => formatProperties(vars.insights).length > 0 || vars.insights?.page_scan?.valueOf();
 const hasVerifyData = (data) => {
-  return data.verify?.languages 
+  return data.verify?.languages
   || data.verify?.result;
 };
 

--- a/lib/trustedform.js
+++ b/lib/trustedform.js
@@ -4,6 +4,7 @@ const { compact, get, pickBy, isUndefined } = require('lodash');
 const request = (vars) => {
   const { lead, trustedform, insights } = vars;
   const body = {};
+  vars.cplToken = vars.cplToken || process.env.TRUSTEDFORM_CPL_TOKEN;
 
   if (trustedform.retain.valueOf() && (lead.email || lead.phone_1)) {
     body.match_lead = {
@@ -40,16 +41,23 @@ const request = (vars) => {
     Authorization: `Basic ${Buffer.from(`X:${trustedform.api_key || vars.activeprospect.api_key}`).toString('base64')}`
   };
 
-  if(process.env.TRUSTEDFORM_CPL_TOKEN) {
-    headers['CPL-Token'] = process.env.TRUSTEDFORM_CPL_TOKEN;
+  if(vars.cplToken) {
+    headers['CPL-Token'] = vars.cplToken;
   }
 
-  return {
+  const req = {
     method: 'POST',
     url: lead.trustedform_cert_url.toString(),
     body: JSON.stringify(body),
     headers
   };
+
+  if(vars.cplToken) {
+    // mask CPL Token
+    vars.cplToken = Array(vars.cplToken.length + 1).join('*');
+  }
+
+  return req;
 };
 
 const formatProperties = (insights) => {

--- a/lib/ui/api/account.js
+++ b/lib/ui/api/account.js
@@ -10,7 +10,7 @@ module.exports = (req, res) => {
     'test': 'https://app.staging.trustedform.com/account',
     'development': 'https://app.trustedform-dev.com/account',
   };
-  const url = trustedFormUrl[process.env.NODE_ENV] || trustedFormUrl['development'];
+  const url = trustedFormUrl[process?.env.NODE_ENV] || trustedFormUrl['development'];
 
   const options = {
     url,

--- a/test/trustedform_spec.js
+++ b/test/trustedform_spec.js
@@ -374,6 +374,14 @@ describe('v4', () => {
     delete process.env.TRUSTEDFORM_CPL_TOKEN;
   });
 
+  it('should mask CPL token on second invocation', () => {
+    process.env.TRUSTEDFORM_CPL_TOKEN = 'test';
+    const vars = baseVars();
+    integration.request(vars);
+    assert.equal(integration.request(vars).headers['CPL-Token'], '****');
+    delete process.env.TRUSTEDFORM_CPL_TOKEN;
+  });
+
   describe('response', () => {
     it('should correctly handle a success response', () => {
       const res = {

--- a/test/trustedform_spec.js
+++ b/test/trustedform_spec.js
@@ -368,6 +368,12 @@ describe('v4', () => {
     assert.equal(integration.request(vars).headers.Authorization, expected);
   });
 
+  it('should send CPL token when present', () => {
+    process.env.TRUSTEDFORM_CPL_TOKEN = 'test';
+    assert.equal(integration.request(baseVars()).headers['CPL-Token'], 'test');
+    delete process.env.TRUSTEDFORM_CPL_TOKEN;
+  });
+
   describe('response', () => {
     it('should correctly handle a success response', () => {
       const res = {


### PR DESCRIPTION
## Description of the change

Because the `Authorization` header is already in use, I opted to stick the token in a custom header

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change
- [ ] Technical Debt
- [ ] Documentation

## Related tickets

https://app.shortcut.com/active-prospect/story/87918/send-cpl-data-to-trustedform

## Checklists

### Development and Testing

- [ ]  Lint rules pass locally.
- [ ]  The code changed/added as part of this pull request has been covered with tests, or this PR does not alter production code.
- [ ]  All tests related to the changed code pass in development, or tests are not applicable.

### Code Review

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.
- [ ]  At least two engineers have been added as "Reviewers" on the pull request.
- [ ]  Changes have been reviewed by at least two other engineers who did not write the code.
- [ ]  This branch has been rebased off master to be current.

### Tracking 
- [ ]  Issue from Shortcut/Jira has a link to this pull request.
- [ ]  This PR has a link to the issue in Shortcut.

### QA
- [ ]  This branch has been deployed to staging and tested.
