### PR TITLE
add support for verify.opt_in_types_satisfied

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org)
 
+## [2.6.0] - 2025-05-05
+### Added
+- v4 Verify now appends `opt_in_type`, based on `opt_in_types_satisfied` ([sc-90678](https://app.shortcut.com/active-prospect/story/90678/trustedform-v4-verify-include-opt-in-types-satisfied-as-an-appended-field))
+
 ## [2.5.0] - 2025-04-08
 ### Added
 - v4 now includes CPL token when present ([sc-87918](https://app.shortcut.com/active-prospect/story/87918/send-cpl-data-to-trustedform))

--- a/lib/trustedform.js
+++ b/lib/trustedform.js
@@ -1,6 +1,7 @@
 const helpers = require('./helpers');
 const { compact, get, pickBy, isUndefined } = require('lodash');
 
+/* eslint-disable-next-line complexity */
 const request = (vars) => {
   const { lead, trustedform, insights } = vars;
   const body = {};
@@ -160,6 +161,7 @@ const response = (vars, req, res) => {
               language_approved: parsed.verify.result?.language_approved,
               font_size: parsed.verify.result?.min_font_size_px_satisfied,
               contrast_ratio: parsed.verify.result?.min_contrast_ratio_satisfied,
+              opt_in_type: parsed.verify.result?.opt_in_types_satisfied,
               // note that the Verify one_to_one value is handled separately
               success: parsed.verify.result?.success,
             }, (v) => !isUndefined(v))
@@ -297,7 +299,8 @@ response.variables = () => [
   { name: 'verify.form_submitted', type: 'boolean', description: 'A boolean indicating whether the form was successfully submitted by the consumer.' },
   { name: 'verify.success', type: 'boolean', description: 'A boolean indicating if any of the consent languages found meet the success criteria defined for your account.' },
   { name: 'verify.font_size', type: 'boolean', description: 'True when the consent language font size meets or exceeds the value configured in TrustedForm.' },
-  { name: 'verify.contrast_ratio', type: 'boolean', description: 'True when the contrast ratio between the consent language text and background meets or exceeds the value configured in TrustedForm.' }
+  { name: 'verify.contrast_ratio', type: 'boolean', description: 'True when the contrast ratio between the consent language text and background meets or exceeds the value configured in TrustedForm' },
+  { name: 'verify.opt_in_type', type: 'boolean', description: 'True when all opt-in types on the form match one or more of the values configured in TrustedForm' }
 ];
 
 const editable = true;

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "axios": "^1.4.0",
     "body-parser": "^1.19.0",
     "express": "^4.17.1",
-    "leadconduit-integration": "^0.4.1",
+    "leadconduit-integration": "^0.6.3",
     "leadconduit-integration-ui": "^1.1.4",
     "lodash": "^4.17.20",
     "request": "^2.88.0",

--- a/test/trustedform_spec.js
+++ b/test/trustedform_spec.js
@@ -486,7 +486,8 @@ describe('v4', () => {
               form_submitted: true,
               one_to_one: true,
               min_font_size_px_satisfied: true,
-              min_contrast_ratio_satisfied: true
+              min_contrast_ratio_satisfied: true,
+              opt_in_types_satisfied: true
             }
           }
         })
@@ -542,7 +543,8 @@ describe('v4', () => {
           form_submitted: true,
           success: true,
           font_size: true,
-          contrast_ratio: true
+          contrast_ratio: true,
+          opt_in_type: true
         }
       };
       assert.deepEqual(integration.response({ insights: { page_scan: true }}, {}, res), expected);


### PR DESCRIPTION
## Description of the change

add support for verify.opt_in_types_satisfied

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change
- [ ] Technical Debt
- [ ] Documentation

## Related tickets

https://app.shortcut.com/active-prospect/story/90678/trustedform-v4-verify-include-opt-in-types-satisfied-as-an-appended-field

## Checklists

### Development and Testing

- [ ]  Lint rules pass locally.
- [ ]  The code changed/added as part of this pull request has been covered with tests, or this PR does not alter production code.
- [ ]  All tests related to the changed code pass in development, or tests are not applicable.

### Code Review

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.
- [ ]  At least two engineers have been added as "Reviewers" on the pull request.
- [ ]  Changes have been reviewed by at least two other engineers who did not write the code.
- [ ]  This branch has been rebased off master to be current.

### Tracking 
- [ ]  Issue from Shortcut/Jira has a link to this pull request.
- [ ]  This PR has a link to the issue in Shortcut.

### QA
- [ ]  This branch has been deployed to staging and tested.
